### PR TITLE
TMEDIA-656-component-link

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 /* eslint import/order: ["error", {"alphabetize": {"order": "asc", "caseInsensitive": true}}] */
 // inject imports after this comment and alphabetize them
+import Link from './src/components/link';
 import Paragraph from './src/components/paragraph';
 
 // Remove eslint disable once we have more than one export
 /* eslint-disable import/prefer-default-export */
 export {
+	Link,
 	Paragraph,
 };

--- a/jest/testSetupFile.js
+++ b/jest/testSetupFile.js
@@ -1,5 +1,5 @@
-import React from 'react';
+import '@testing-library/jest-dom';
 
 beforeEach(() => {
-  jest.resetModules();
+	jest.resetModules();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4269,6 +4269,41 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
+      "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^5.0.0",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.5.6",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "aria-query": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "12.1.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
@@ -4409,6 +4444,16 @@
       "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
+      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.0.0",
+        "pretty-format": "^27.0.0"
       }
     },
     "@types/json-schema": {
@@ -4571,6 +4616,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
       "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
+      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/uglify-js": {
       "version": "3.13.1",
@@ -7528,6 +7582,12 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
       "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@storybook/react": "^6.4.14",
     "@storybook/theming": "^6.4.14",
     "@testing-library/dom": "^8.11.2",
+    "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "babel-jest": "^27.4.6",
     "chromatic": "^6.4.1",

--- a/scss.scss
+++ b/scss.scss
@@ -1,3 +1,5 @@
 @forward 'src/scss';
 
 // @use '@wpmedia/arc-themes-components/scss';
+@use './src/components/link';
+

--- a/src/components/link/_index.scss
+++ b/src/components/link/_index.scss
@@ -1,0 +1,5 @@
+@use '../../scss';
+
+.c-link {
+	@include scss.component-properties('link');
+}

--- a/src/components/link/_index.scss
+++ b/src/components/link/_index.scss
@@ -2,4 +2,16 @@
 
 .c-link {
 	@include scss.component-properties('link');
+
+	&:hover {
+		@include scss.component-properties('link-hover');
+	}
+
+	&:active {
+		@include scss.component-properties('link-active');
+	}
+
+	&:visited {
+		@include scss.component-properties('link-visited');
+	}
 }

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -8,6 +8,7 @@ const LinkOpeningInNewTab = ({
 	className,
 	href,
 	openNewTabLinkHiddenText,
+	title,
 }) => (
 	<a
 		aria-hidden={assistiveHidden ? 'true' : undefined}
@@ -16,6 +17,7 @@ const LinkOpeningInNewTab = ({
 		href={href}
 		rel="noreferrer"
 		target="_blank"
+		title={title || undefined}
 	>
 		{children}
 		<span className="visually-hidden">{openNewTabLinkHiddenText}</span>
@@ -29,6 +31,7 @@ const Link = ({
 	href,
 	openInNewTab,
 	openNewTabLinkHiddenText,
+	title,
 }) => {
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
@@ -42,6 +45,7 @@ const Link = ({
 				className={defaultAndAdditionalClassnames}
 				href={href}
 				openNewTabLinkHiddenText={openNewTabLinkHiddenText}
+				title={title}
 			>
 				{children}
 			</LinkOpeningInNewTab>
@@ -50,10 +54,11 @@ const Link = ({
 
 	return (
 		<a
+			aria-hidden={assistiveHidden ? 'true' : undefined}
 			className={defaultAndAdditionalClassnames}
 			href={href}
-			aria-hidden={assistiveHidden ? 'true' : undefined}
 			tabIndex={assistiveHidden ? '-1' : undefined}
+			title={title || undefined}
 		>
 			{children}
 		</a>
@@ -67,6 +72,7 @@ Link.propTypes = {
 	href: PropTypes.string.isRequired,
 	openInNewTab: PropTypes.bool,
 	openNewTabLinkHiddenText: PropTypes.string,
+	title: PropTypes.string,
 };
 
 Link.defaultProps = {
@@ -74,6 +80,7 @@ Link.defaultProps = {
 	assistiveHidden: false,
 	openInNewTab: undefined,
 	openNewTabLinkHiddenText: 'Opens in new window',
+	title: undefined,
 };
 
 export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -32,12 +32,19 @@ const Link = ({
 };
 
 Link.propTypes = {
+	/** Classnames that get appended to default c-link classname */
 	additionalClassNames: PropTypes.string,
+	/** Remove the link from the accessibility tree with aria-hidden, tab-index=-1 */
 	assistiveHidden: PropTypes.bool,
+	/** The text, images or any node that will be displayed within the link */
 	children: PropTypes.node.isRequired,
+	/** The destination of the link */
 	href: PropTypes.string.isRequired,
+	/** Opt to open the link in a new tab */
 	openInNewTab: PropTypes.bool,
+	/** Text to make the link's purpose more clear to screen readers indicating a new tab */
 	openNewTabLinkVisuallyHiddenText: PropTypes.string,
+	/** Text to make the link's purpose more clear to screen readers */
 	supplementalText: PropTypes.string,
 };
 

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 
 const Link = ({
 	additionalClassNames,
-	additionalHiddenText,
 	assistiveHidden,
 	children,
 	href,
 	openInNewTab,
-	openNewTabLinkHiddenText,
+	openNewTabLinkVisuallyHiddenText,
+	supplementalText,
 }) => {
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
@@ -25,28 +25,28 @@ const Link = ({
 			target={opensInNewTab ? '_blank' : undefined}
 		>
 			{children}
-			{opensInNewTab ? (<span className="visually-hidden">{openNewTabLinkHiddenText}</span>) : null}
-			{additionalHiddenText ? (<span className="visually-hidden">{additionalHiddenText}</span>) : null}
+			{opensInNewTab ? (<span className="visually-hidden">{openNewTabLinkVisuallyHiddenText}</span>) : null}
+			{supplementalText ? (<span className="visually-hidden">{supplementalText}</span>) : null}
 		</a>
 	);
 };
 
 Link.propTypes = {
 	additionalClassNames: PropTypes.string,
-	additionalHiddenText: PropTypes.string,
 	assistiveHidden: PropTypes.bool,
 	children: PropTypes.node.isRequired,
 	href: PropTypes.string.isRequired,
 	openInNewTab: PropTypes.bool,
-	openNewTabLinkHiddenText: PropTypes.string,
+	openNewTabLinkVisuallyHiddenText: PropTypes.string,
+	supplementalText: PropTypes.string,
 };
 
 Link.defaultProps = {
 	additionalClassNames: '',
-	additionalHiddenText: '',
 	assistiveHidden: false,
 	openInNewTab: undefined,
-	openNewTabLinkHiddenText: 'Opens in new window',
+	openNewTabLinkVisuallyHiddenText: 'Opens in new window',
+	supplementalText: '',
 };
 
 export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -44,7 +44,10 @@ Link.propTypes = {
 	openInNewTab: PropTypes.bool,
 	/** Text to make the link's purpose more clear to screen readers indicating a new tab */
 	openNewTabLinkVisuallyHiddenText: PropTypes.string,
-	/** Text to make the link's purpose more clear to screen readers, do not use in conjunction with `openNewTabLinkVisuallyHiddenText` */
+	/**
+	 	Text to make the link's purpose more clear to screen readers.
+		(Do not use in conjunction with `openNewTabLinkVisuallyHiddenText`.)
+	*/
 	supplementalText: PropTypes.string,
 };
 

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,0 +1,47 @@
+import PropTypes from 'prop-types';
+
+const COMPONENT_CLASS_NAME = 'c-link';
+
+const ExternalLink = ({ children, href }) => (
+	<a
+		className={COMPONENT_CLASS_NAME}
+		href={href}
+		rel="noreferrer"
+		target="_blank"
+	>
+		<span className="visually-hidden">Opens in new window</span>
+		{children}
+	</a>
+);
+
+const Link = ({ children, href, isExternal }) => {
+	// internal link by default
+	if (isExternal) {
+		return (
+			<ExternalLink href={href}>
+				{children}
+			</ExternalLink>
+		);
+	}
+
+	return (
+		<a
+			className={COMPONENT_CLASS_NAME}
+			href={href}
+		>
+			{children}
+		</a>
+	);
+};
+
+Link.propTypes = {
+	children: PropTypes.node.isRequired,
+	href: PropTypes.string.isRequired,
+	isExternal: PropTypes.bool,
+};
+
+Link.defaultProps = {
+	isExternal: false,
+};
+
+export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -80,7 +80,7 @@ Link.defaultProps = {
 	assistiveHidden: false,
 	openInNewTab: undefined,
 	openNewTabLinkHiddenText: 'Opens in new window',
-	title: undefined,
+	title: '',
 };
 
 export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -3,12 +3,15 @@ import PropTypes from 'prop-types';
 const COMPONENT_CLASS_NAME = 'c-link';
 
 const LinkOpeningInNewTab = ({
+	assistiveHidden,
 	children,
 	className,
 	href,
 	openNewTabLinkHiddenText,
 }) => (
 	<a
+		aria-hidden={assistiveHidden ? 'true' : undefined}
+		tabIndex={assistiveHidden ? '-1' : undefined}
 		className={className}
 		href={href}
 		rel="noreferrer"
@@ -21,6 +24,7 @@ const LinkOpeningInNewTab = ({
 
 const Link = ({
 	additionalClassNames,
+	assistiveHidden,
 	children,
 	href,
 	openInNewTab,
@@ -34,6 +38,7 @@ const Link = ({
 	if (opensInNewTab) {
 		return (
 			<LinkOpeningInNewTab
+				assistiveHidden={assistiveHidden}
 				className={defaultAndAdditionalClassnames}
 				href={href}
 				openNewTabLinkHiddenText={openNewTabLinkHiddenText}
@@ -47,6 +52,8 @@ const Link = ({
 		<a
 			className={defaultAndAdditionalClassnames}
 			href={href}
+			aria-hidden={assistiveHidden ? 'true' : undefined}
+			tabIndex={assistiveHidden ? '-1' : undefined}
 		>
 			{children}
 		</a>
@@ -55,6 +62,7 @@ const Link = ({
 
 Link.propTypes = {
 	additionalClassNames: PropTypes.string,
+	assistiveHidden: PropTypes.bool,
 	children: PropTypes.node.isRequired,
 	href: PropTypes.string.isRequired,
 	openInNewTab: PropTypes.bool,
@@ -63,6 +71,7 @@ Link.propTypes = {
 
 Link.defaultProps = {
 	additionalClassNames: '',
+	assistiveHidden: false,
 	openInNewTab: undefined,
 	openNewTabLinkHiddenText: 'Opens in new window',
 };

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -8,7 +8,6 @@ const LinkOpeningInNewTab = ({
 	className,
 	href,
 	openNewTabLinkHiddenText,
-	title,
 }) => (
 	<a
 		aria-hidden={assistiveHidden ? 'true' : undefined}
@@ -17,7 +16,6 @@ const LinkOpeningInNewTab = ({
 		href={href}
 		rel="noreferrer"
 		target="_blank"
-		title={title || undefined}
 	>
 		{children}
 		<span className="visually-hidden">{openNewTabLinkHiddenText}</span>
@@ -31,7 +29,6 @@ const Link = ({
 	href,
 	openInNewTab,
 	openNewTabLinkHiddenText,
-	title,
 }) => {
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
@@ -45,7 +42,6 @@ const Link = ({
 				className={defaultAndAdditionalClassnames}
 				href={href}
 				openNewTabLinkHiddenText={openNewTabLinkHiddenText}
-				title={title}
 			>
 				{children}
 			</LinkOpeningInNewTab>
@@ -54,11 +50,10 @@ const Link = ({
 
 	return (
 		<a
-			aria-hidden={assistiveHidden ? 'true' : undefined}
 			className={defaultAndAdditionalClassnames}
 			href={href}
+			aria-hidden={assistiveHidden ? 'true' : undefined}
 			tabIndex={assistiveHidden ? '-1' : undefined}
-			title={title || undefined}
 		>
 			{children}
 		</a>
@@ -72,7 +67,6 @@ Link.propTypes = {
 	href: PropTypes.string.isRequired,
 	openInNewTab: PropTypes.bool,
 	openNewTabLinkHiddenText: PropTypes.string,
-	title: PropTypes.string,
 };
 
 Link.defaultProps = {
@@ -80,7 +74,6 @@ Link.defaultProps = {
 	assistiveHidden: false,
 	openInNewTab: undefined,
 	openNewTabLinkHiddenText: 'Opens in new window',
-	title: '',
 };
 
 export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -2,31 +2,50 @@ import PropTypes from 'prop-types';
 
 const COMPONENT_CLASS_NAME = 'c-link';
 
-const ExternalLink = ({ children, href }) => (
+const LinkOpeningInNewTab = ({
+	children,
+	className,
+	href,
+	openNewTabLinkHiddenText,
+}) => (
 	<a
-		className={COMPONENT_CLASS_NAME}
+		className={className}
 		href={href}
 		rel="noreferrer"
 		target="_blank"
 	>
-		<span className="visually-hidden">Opens in new window</span>
 		{children}
+		<span className="visually-hidden">{openNewTabLinkHiddenText}</span>
 	</a>
 );
 
-const Link = ({ children, href, isExternal }) => {
-	// internal link by default
-	if (isExternal) {
+const Link = ({
+	additionalClassNames,
+	children,
+	href,
+	openInNewTab,
+	openNewTabLinkHiddenText,
+}) => {
+	// openInNewTab is undefined by default
+	// http or https link or openInNewTab can be either true or undefined for opening in new tab
+	const opensInNewTab = (href.startsWith('http') && openInNewTab !== false) || openInNewTab === true;
+	const defaultAndAdditionalClassnames = `${COMPONENT_CLASS_NAME}${additionalClassNames ? ` ${additionalClassNames}` : ''}`;
+
+	if (opensInNewTab) {
 		return (
-			<ExternalLink href={href}>
+			<LinkOpeningInNewTab
+				className={defaultAndAdditionalClassnames}
+				href={href}
+				openNewTabLinkHiddenText={openNewTabLinkHiddenText}
+			>
 				{children}
-			</ExternalLink>
+			</LinkOpeningInNewTab>
 		);
 	}
 
 	return (
 		<a
-			className={COMPONENT_CLASS_NAME}
+			className={defaultAndAdditionalClassnames}
 			href={href}
 		>
 			{children}
@@ -35,13 +54,17 @@ const Link = ({ children, href, isExternal }) => {
 };
 
 Link.propTypes = {
+	additionalClassNames: PropTypes.string,
 	children: PropTypes.node.isRequired,
 	href: PropTypes.string.isRequired,
-	isExternal: PropTypes.bool,
+	openInNewTab: PropTypes.bool,
+	openNewTabLinkHiddenText: PropTypes.string,
 };
 
 Link.defaultProps = {
-	isExternal: false,
+	additionalClassNames: '',
+	openInNewTab: undefined,
+	openNewTabLinkHiddenText: 'Opens in new window',
 };
 
 export default Link;

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -34,7 +34,7 @@ const Link = ({
 Link.propTypes = {
 	/** Classnames that get appended to default c-link classname */
 	additionalClassNames: PropTypes.string,
-	/** Remove the link from the accessibility tree with aria-hidden, tab-index=-1 */
+	/** Remove the link from the accessibility tree with aria-hidden, tabindex=-1 */
 	assistiveHidden: PropTypes.bool,
 	/** The text, images or any node that will be displayed within the link */
 	children: PropTypes.node.isRequired,

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,19 +1,32 @@
 /* eslint-disable react/jsx-no-target-blank */
 import PropTypes from 'prop-types';
 
+function determineVisuallyHiddenText(supplementalText, opensInNewTab) {
+	if (supplementalText) {
+		return supplementalText;
+	}
+
+	if (opensInNewTab) {
+		return 'Opens in new window';
+	}
+
+	return '';
+}
+
 const Link = ({
 	additionalClassNames,
 	assistiveHidden,
 	children,
 	href,
 	openInNewTab,
-	openNewTabLinkVisuallyHiddenText,
 	supplementalText,
 }) => {
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
 	const opensInNewTab = (href.startsWith('http') && openInNewTab !== false) || openInNewTab === true;
 	const defaultAndAdditionalClassnames = `c-link${additionalClassNames ? ` ${additionalClassNames}` : ''}`;
+
+	const visuallyHiddenText = determineVisuallyHiddenText(supplementalText, opensInNewTab);
 
 	return (
 		<a
@@ -25,8 +38,7 @@ const Link = ({
 			target={opensInNewTab ? '_blank' : undefined}
 		>
 			{children}
-			{opensInNewTab ? (<span className="visually-hidden">{openNewTabLinkVisuallyHiddenText}</span>) : null}
-			{supplementalText ? (<span className="visually-hidden">{supplementalText}</span>) : null}
+			{visuallyHiddenText ? (<span className="visually-hidden">{visuallyHiddenText}</span>) : null}
 		</a>
 	);
 };
@@ -42,11 +54,9 @@ Link.propTypes = {
 	href: PropTypes.string.isRequired,
 	/** Opt to open the link in a new tab */
 	openInNewTab: PropTypes.bool,
-	/** Text to make the link's purpose more clear to screen readers indicating a new tab */
-	openNewTabLinkVisuallyHiddenText: PropTypes.string,
 	/**
-	 	Text to make the link's purpose more clear to screen readers.
-		(Do not use in conjunction with `openNewTabLinkVisuallyHiddenText`.)
+	 Text to make the link's purpose more clear to screen readers
+	 indicating a new tab in English by default if external link or opting into a new tab
 	*/
 	supplementalText: PropTypes.string,
 };
@@ -55,7 +65,6 @@ Link.defaultProps = {
 	additionalClassNames: '',
 	assistiveHidden: false,
 	openInNewTab: undefined,
-	openNewTabLinkVisuallyHiddenText: 'Opens in new window',
 	supplementalText: '',
 };
 

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,29 +1,9 @@
+/* eslint-disable react/jsx-no-target-blank */
 import PropTypes from 'prop-types';
-
-const COMPONENT_CLASS_NAME = 'c-link';
-
-const LinkOpeningInNewTab = ({
-	assistiveHidden,
-	children,
-	className,
-	href,
-	openNewTabLinkHiddenText,
-}) => (
-	<a
-		aria-hidden={assistiveHidden ? 'true' : undefined}
-		tabIndex={assistiveHidden ? '-1' : undefined}
-		className={className}
-		href={href}
-		rel="noreferrer"
-		target="_blank"
-	>
-		{children}
-		<span className="visually-hidden">{openNewTabLinkHiddenText}</span>
-	</a>
-);
 
 const Link = ({
 	additionalClassNames,
+	additionalHiddenText,
 	assistiveHidden,
 	children,
 	href,
@@ -33,20 +13,7 @@ const Link = ({
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
 	const opensInNewTab = (href.startsWith('http') && openInNewTab !== false) || openInNewTab === true;
-	const defaultAndAdditionalClassnames = `${COMPONENT_CLASS_NAME}${additionalClassNames ? ` ${additionalClassNames}` : ''}`;
-
-	if (opensInNewTab) {
-		return (
-			<LinkOpeningInNewTab
-				assistiveHidden={assistiveHidden}
-				className={defaultAndAdditionalClassnames}
-				href={href}
-				openNewTabLinkHiddenText={openNewTabLinkHiddenText}
-			>
-				{children}
-			</LinkOpeningInNewTab>
-		);
-	}
+	const defaultAndAdditionalClassnames = `c-link${additionalClassNames ? ` ${additionalClassNames}` : ''}`;
 
 	return (
 		<a
@@ -54,14 +21,19 @@ const Link = ({
 			href={href}
 			aria-hidden={assistiveHidden ? 'true' : undefined}
 			tabIndex={assistiveHidden ? '-1' : undefined}
+			rel={opensInNewTab ? 'noreferrer' : undefined}
+			target={opensInNewTab ? '_blank' : undefined}
 		>
 			{children}
+			{opensInNewTab ? (<span className="visually-hidden">{openNewTabLinkHiddenText}</span>) : null}
+			{additionalHiddenText ? (<span className="visually-hidden">{additionalHiddenText}</span>) : null}
 		</a>
 	);
 };
 
 Link.propTypes = {
 	additionalClassNames: PropTypes.string,
+	additionalHiddenText: PropTypes.string,
 	assistiveHidden: PropTypes.bool,
 	children: PropTypes.node.isRequired,
 	href: PropTypes.string.isRequired,
@@ -71,6 +43,7 @@ Link.propTypes = {
 
 Link.defaultProps = {
 	additionalClassNames: '',
+	additionalHiddenText: '',
 	assistiveHidden: false,
 	openInNewTab: undefined,
 	openNewTabLinkHiddenText: 'Opens in new window',

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -44,7 +44,7 @@ Link.propTypes = {
 	openInNewTab: PropTypes.bool,
 	/** Text to make the link's purpose more clear to screen readers indicating a new tab */
 	openNewTabLinkVisuallyHiddenText: PropTypes.string,
-	/** Text to make the link's purpose more clear to screen readers */
+	/** Text to make the link's purpose more clear to screen readers, do not use in conjunction with `openNewTabLinkVisuallyHiddenText` */
 	supplementalText: PropTypes.string,
 };
 

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -32,7 +32,7 @@ const Link = ({
 };
 
 Link.propTypes = {
-	/** Classnames that get appended to default c-link classname */
+	/** Class name(s) that get appended to default class name of the component */
 	additionalClassNames: PropTypes.string,
 	/** Remove the link from the accessibility tree with aria-hidden, tabindex=-1 */
 	assistiveHidden: PropTypes.bool,

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -10,20 +10,38 @@ import Link from '.';
 
 ## Usage
 
-Link
+By default, the Link component is secure and accessible. The link is for enclosing all contents with a link. There are security considerations made here by opting into using "rel=noreferrer" when opening the link in a new tab. In terms of accessibility, there is visually hidden text indicating to the user of the link behavior.
+
+In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `openNewTabLinkHiddenText`.
+
+By default, the link will open in a new tab if the `href` property starts with http or https. Yet this can be overridden with the `opensInNewTab` prop.
 
 ## Stories
 
-** External Link **
+** External Link Due To Link Contents **
 <Preview>
-	<Story name="External Link">
-		<Link href="https://www.arcxp.com/" isExternal>External Link to Arc XP</Link>
+	<Story name="External Link Due To Link Contents">
+		<Link href="https://www.arcxp.com/">External Link to Arc XP</Link>
 	</Story>
 </Preview>
 
-** Internal Link **
+** Internal Link Due To Link Contents **
 <Preview>
-	<Story name="Internal Link">
+	<Story name="Internal Link Due To Link Contents">
 		<Link href="/">Internal Link to Home</Link>
+	</Story>
+</Preview>
+
+** Internal Link Due To Opting Into Same Tab **
+<Preview>
+	<Story name="Internal Link Due To Opting Into Same Tab">
+		<Link href="https://www.arcxp.com/" openInNewTab={false}>Go to Arc XP without going to a new tab</Link>
+	</Story>
+</Preview>
+
+** External Link Due To Opting Into New Tab **
+<Preview>
+	<Story name="External Link Due To Opting Into New Tab">
+		<Link href="/" openInNewTab={true}>Open "/" in a new tab</Link>
 	</Story>
 </Preview>

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -12,7 +12,7 @@ import Link from '.';
 
 By default, the Link component is secure and accessible. The link is for enclosing all contents with a link. There are security considerations made here by opting into using "rel=noreferrer" when opening the link in a new tab. In terms of accessibility, there is visually hidden text indicating to the user of the link behavior.
 
-In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `openNewTabLinkVisuallyHiddenText`.
+In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `supplementalText`.
 
 By default, the link will open in a new tab if the `href` property starts with http or https. Yet this can be overridden with the `opensInNewTab` prop.
 

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -12,7 +12,7 @@ import Link from '.';
 
 By default, the Link component is secure and accessible. The link is for enclosing all contents with a link. There are security considerations made here by opting into using "rel=noreferrer" when opening the link in a new tab. In terms of accessibility, there is visually hidden text indicating to the user of the link behavior.
 
-In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `openNewTabLinkHiddenText`.
+In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `openNewTabLinkVisuallyHiddenText`.
 
 By default, the link will open in a new tab if the `href` property starts with http or https. Yet this can be overridden with the `opensInNewTab` prop.
 
@@ -43,5 +43,18 @@ By default, the link will open in a new tab if the `href` property starts with h
 <Preview>
 	<Story name="External Link Due To Opting Into New Tab">
 		<Link href="/" openInNewTab={true}>Open "/" in a new tab</Link>
+	</Story>
+</Preview>
+
+** Custom accessible text ** 
+<Preview>
+	<Story name="Custom accessible text">
+		<Link 
+			href="https://www.arcxp.com/"
+			openNewTabLinkVisuallyHiddenText="Go to that page"
+			supplementalText="This link will give you new insight into the Arc XP company"
+		>
+			Arc XP
+		</Link>
 	</Story>
 </Preview>

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -1,0 +1,29 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs';
+
+import Link from '.';
+
+<Meta title="Components/Link" component={Link} />
+
+# Link
+
+<Props of={Link} />
+
+## Usage
+
+Link
+
+## Stories
+
+** External Link **
+<Preview>
+	<Story name="External Link">
+		<Link href="https://www.arcxp.com/" isExternal>External Link to Arc XP</Link>
+	</Story>
+</Preview>
+
+** Internal Link **
+<Preview>
+	<Story name="Internal Link">
+		<Link href="/">Internal Link to Home</Link>
+	</Story>
+</Preview>

--- a/src/components/link/index.stories.mdx
+++ b/src/components/link/index.stories.mdx
@@ -6,15 +6,29 @@ import Link from '.';
 
 # Link
 
-<Props of={Link} />
-
-## Usage
-
 By default, the Link component is secure and accessible. The link is for enclosing all contents with a link. There are security considerations made here by opting into using "rel=noreferrer" when opening the link in a new tab. In terms of accessibility, there is visually hidden text indicating to the user of the link behavior.
 
 In addition, the Link component is customizable. That accessible text can be customized or translated by passing in a prop `supplementalText`.
 
 By default, the link will open in a new tab if the `href` property starts with http or https. Yet this can be overridden with the `opensInNewTab` prop.
+
+## Usage
+
+```
+import { Link } from '@wpmedia/arc-themes-components';
+
+
+<Link 
+	href="https://www.arcxp.com/" 
+	supplementalText="The Arc XP page will open in a new window"
+>
+	See Arc XP Homepage
+</Link>
+```
+
+## Properties
+
+<Props of={Link} />
 
 ## Stories
 

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+
+import Link from '.';
+
+const LINK_DESTINATION = 'https://www.arcxp.com/';
+const LINK_TEXT = 'Arc XP';
+
+describe('Link', () => {
+	it('should render string child', () => {
+		render(<Link href={LINK_DESTINATION}>{LINK_TEXT}</Link>);
+
+		expect(screen.queryByText(LINK_TEXT)).not.toBeNull();
+	});
+	it('should render rel property and target blank for external links', () => {
+		render(<Link href={LINK_DESTINATION} isExternal>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveAttribute('rel', 'noreferrer');
+		expect(linkOutput).toHaveAttribute('target', '_blank');
+	});
+	it('should not render rel property and target blank by default for internal links', () => {
+		render(<Link href={LINK_DESTINATION}>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).not.toHaveAttribute('rel');
+		expect(linkOutput).not.toHaveAttribute('target');
+	});
+});

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -2,17 +2,26 @@ import { render, screen } from '@testing-library/react';
 
 import Link from '.';
 
-const LINK_DESTINATION = 'https://www.arcxp.com/';
+const EXTERNAL_LINK_DESTINATION = 'https://www.arcxp.com/';
+const INTERNAL_LINK_DESTINATION = '/';
 const LINK_TEXT = 'Arc XP';
 
 describe('Link', () => {
 	it('should render string child', () => {
-		render(<Link href={LINK_DESTINATION}>{LINK_TEXT}</Link>);
+		render(<Link href={EXTERNAL_LINK_DESTINATION}>{LINK_TEXT}</Link>);
 
 		expect(screen.queryByText(LINK_TEXT)).not.toBeNull();
 	});
 	it('should render rel property and target blank for external links', () => {
-		render(<Link href={LINK_DESTINATION} isExternal>{LINK_TEXT}</Link>);
+		render(<Link href={EXTERNAL_LINK_DESTINATION} isExternal>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveAttribute('rel', 'noreferrer');
+		expect(linkOutput).toHaveAttribute('target', '_blank');
+	});
+	it('should render rel property and target blank for internal links electing to open in new tab', () => {
+		render(<Link href={INTERNAL_LINK_DESTINATION} openInNewTab>{LINK_TEXT}</Link>);
 
 		const linkOutput = screen.queryByText(LINK_TEXT);
 
@@ -20,11 +29,26 @@ describe('Link', () => {
 		expect(linkOutput).toHaveAttribute('target', '_blank');
 	});
 	it('should not render rel property and target blank by default for internal links', () => {
-		render(<Link href={LINK_DESTINATION}>{LINK_TEXT}</Link>);
+		render(<Link href={INTERNAL_LINK_DESTINATION}>{LINK_TEXT}</Link>);
 
 		const linkOutput = screen.queryByText(LINK_TEXT);
 
 		expect(linkOutput).not.toHaveAttribute('rel');
 		expect(linkOutput).not.toHaveAttribute('target');
+	});
+	it('should not render rel property and target blank for external links electing to open in the same tab', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} openInNewTab={false}>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).not.toHaveAttribute('rel');
+		expect(linkOutput).not.toHaveAttribute('target');
+	});
+	it('should take in additional classnames', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} additionalClassNames="test-class">{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveClass('test-class');
 	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -71,9 +71,27 @@ describe('Link', () => {
 		render(<Link href={EXTERNAL_LINK_DESTINATION} supplementalText="RSS Link">{LINK_TEXT}</Link>);
 
 		const additionalHiddenText = screen.queryByText('RSS Link');
-		const newTabDefaultText = screen.queryByText('Opens in new window');
 
 		expect(additionalHiddenText).toHaveClass('visually-hidden');
-		expect(newTabDefaultText).toHaveClass('visually-hidden');
+	});
+	it('should render default open new tab text if no supplemental text and new tab', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION}>{LINK_TEXT}</Link>);
+
+		const additionalHiddenText = screen.queryByText('Opens in new window');
+
+		expect(additionalHiddenText).toHaveClass('visually-hidden');
+	});
+	it('should render no supplemental text if no supplemental text and same tab', () => {
+		render(<Link href="/">{LINK_TEXT}</Link>);
+
+		const additionalHiddenText = screen.queryByText('Opens in new window');
+		expect(additionalHiddenText).toBeNull();
+	});
+	it('should render supplemental text regardless of new tab behavior', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} openInNewTab supplementalText="RSS Link">{LINK_TEXT}</Link>);
+
+		const additionalHiddenText = screen.queryByText('RSS Link');
+
+		expect(additionalHiddenText).toHaveClass('visually-hidden');
 	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -67,20 +67,13 @@ describe('Link', () => {
 		expect(linkOutput).not.toHaveAttribute('aria-hidden');
 		expect(linkOutput).not.toHaveAttribute('tabIndex');
 	});
-	it('should respond to assistiveHidden and show tab index -1 and aria-hidden as internal link', () => {
-		render(<Link href={INTERNAL_LINK_DESTINATION} assistiveHidden>{LINK_TEXT}</Link>);
+	it('should render hidden text with visually-hidden class', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} additionalHiddenText="RSS Link">{LINK_TEXT}</Link>);
 
-		const linkOutput = screen.queryByText(LINK_TEXT);
+		const additionalHiddenText = screen.queryByText('RSS Link');
+		const newTabDefaultText = screen.queryByText('Opens in new window');
 
-		expect(linkOutput).toHaveAttribute('aria-hidden', 'true');
-		expect(linkOutput).toHaveAttribute('tabIndex', '-1');
-	});
-	it('should not show assistive hidden properties if false as internal link', () => {
-		render(<Link href={INTERNAL_LINK_DESTINATION} assistiveHidden={false}>{LINK_TEXT}</Link>);
-
-		const linkOutput = screen.queryByText(LINK_TEXT);
-
-		expect(linkOutput).not.toHaveAttribute('aria-hidden');
-		expect(linkOutput).not.toHaveAttribute('tabIndex');
+		expect(additionalHiddenText).toHaveClass('visually-hidden');
+		expect(newTabDefaultText).toHaveClass('visually-hidden');
 	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -83,18 +83,4 @@ describe('Link', () => {
 		expect(linkOutput).not.toHaveAttribute('aria-hidden');
 		expect(linkOutput).not.toHaveAttribute('tabIndex');
 	});
-	it('takes in a title', () => {
-		render(<Link href={EXTERNAL_LINK_DESTINATION} title="test-title">{LINK_TEXT}</Link>);
-
-		const linkOutput = screen.queryByText(LINK_TEXT);
-
-		expect(linkOutput).toHaveAttribute('title', 'test-title');
-	});
-	it('does not render a title by default', () => {
-		render(<Link href={EXTERNAL_LINK_DESTINATION}>{LINK_TEXT}</Link>);
-
-		const linkOutput = screen.queryByText(LINK_TEXT);
-
-		expect(linkOutput).not.toHaveAttribute('title');
-	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -51,4 +51,36 @@ describe('Link', () => {
 
 		expect(linkOutput).toHaveClass('test-class');
 	});
+	it('should respond to assistiveHidden and show tab index -1 and aria-hidden', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} assistiveHidden>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveAttribute('aria-hidden', 'true');
+		expect(linkOutput).toHaveAttribute('tabIndex', '-1');
+	});
+	it('should not show assistive hidden properties if false', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} assistiveHidden={false}>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).not.toHaveAttribute('aria-hidden');
+		expect(linkOutput).not.toHaveAttribute('tabIndex');
+	});
+	it('should respond to assistiveHidden and show tab index -1 and aria-hidden as internal link', () => {
+		render(<Link href={INTERNAL_LINK_DESTINATION} assistiveHidden>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveAttribute('aria-hidden', 'true');
+		expect(linkOutput).toHaveAttribute('tabIndex', '-1');
+	});
+	it('should not show assistive hidden properties if false as internal link', () => {
+		render(<Link href={INTERNAL_LINK_DESTINATION} assistiveHidden={false}>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).not.toHaveAttribute('aria-hidden');
+		expect(linkOutput).not.toHaveAttribute('tabIndex');
+	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -83,4 +83,18 @@ describe('Link', () => {
 		expect(linkOutput).not.toHaveAttribute('aria-hidden');
 		expect(linkOutput).not.toHaveAttribute('tabIndex');
 	});
+	it('takes in a title', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION} title="test-title">{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).toHaveAttribute('title', 'test-title');
+	});
+	it('does not render a title by default', () => {
+		render(<Link href={EXTERNAL_LINK_DESTINATION}>{LINK_TEXT}</Link>);
+
+		const linkOutput = screen.queryByText(LINK_TEXT);
+
+		expect(linkOutput).not.toHaveAttribute('title');
+	});
 });

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -68,7 +68,7 @@ describe('Link', () => {
 		expect(linkOutput).not.toHaveAttribute('tabIndex');
 	});
 	it('should render hidden text with visually-hidden class', () => {
-		render(<Link href={EXTERNAL_LINK_DESTINATION} additionalHiddenText="RSS Link">{LINK_TEXT}</Link>);
+		render(<Link href={EXTERNAL_LINK_DESTINATION} supplementalText="RSS Link">{LINK_TEXT}</Link>);
 
 		const additionalHiddenText = screen.queryByText('RSS Link');
 		const newTabDefaultText = screen.queryByText('Opens in new window');


### PR DESCRIPTION
Todo: 

- Add text documentation for this components usage
-> potentially include hover state names, etc  

TMEDIA-656 https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-656&assignee=5e387d6a1b1d910e5dfd7a9b

# Test 

1. Look at storybook to see external and internal links
2. Inspect to see the visually-hidden Open in new tab text in the external link
3. Link accounts for different states

# Notes 

- Defaulted to an internal link 
- Noopener is implied with noreferred https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer 
- Added title as it's used in a couple places in the blocks