### PR TITLE
tmedia-657 heading enhanced style 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 /* eslint import/order: ["error", {"alphabetize": {"order": "asc", "caseInsensitive": true}}] */
 // inject imports after this comment and alphabetize them
+import Heading from './src/components/headings/heading';
+import HeadingSection from './src/components/headings/section';
 import Link from './src/components/link';
 import Paragraph from './src/components/paragraph';
 
-// Remove eslint disable once we have more than one export
-/* eslint-disable import/prefer-default-export */
 export {
+	Heading,
+	HeadingSection,
 	Link,
 	Paragraph,
 };

--- a/scss.scss
+++ b/scss.scss
@@ -2,5 +2,4 @@
 
 @use './src/components/link';
 
-@use './src/components/heading';
-
+@use './src/components/headings';

--- a/scss.scss
+++ b/scss.scss
@@ -1,5 +1,6 @@
 @forward 'src/scss';
 
-// @use '@wpmedia/arc-themes-components/scss';
 @use './src/components/link';
+
+@use './src/components/heading';
 

--- a/src/components/headings/_index.scss
+++ b/src/components/headings/_index.scss
@@ -1,0 +1,5 @@
+@use '../../scss';
+
+.c-heading {
+	@include scss.component-properties('heading');
+}

--- a/src/components/headings/context.js
+++ b/src/components/headings/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const LevelContext = React.createContext(1);
+
+export default LevelContext;

--- a/src/components/headings/heading/index.jsx
+++ b/src/components/headings/heading/index.jsx
@@ -1,0 +1,25 @@
+import PropTypes from 'prop-types';
+import LevelContext from '../context';
+
+const COMPONENT_CLASS_NAME = 'c-heading';
+
+const Heading = ({ additionalClassNames = '', children }) => (
+	<LevelContext.Consumer>
+		{(level) => {
+			const allClasses = `${COMPONENT_CLASS_NAME}${additionalClassNames ? ` ${additionalClassNames}` : ''}`;
+			// max heading level is 6
+			const HeadingTag = `h${Math.min(level, 6)}`;
+
+			return <HeadingTag className={allClasses}>{children}</HeadingTag>;
+		}}
+	</LevelContext.Consumer>
+);
+
+Heading.propTypes = {
+	/** Class name(s) that get appended to default class name of the component */
+	additionalClassNames: PropTypes.string,
+	/** The text, images or any node that will be displayed within the component */
+	children: PropTypes.node.isRequired,
+};
+
+export default Heading;

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -31,7 +31,7 @@ In addition, the `<Heading>` component is customizable because custom classes ca
 import { Heading } from '@wpmedia/arc-themes-components';
 
 const BlockFeature = () => (
-  <Heading>Heading Children</Heading>
+	<Heading>Heading Children</Heading>
 )
 ```
 
@@ -41,15 +41,15 @@ const BlockFeature = () => (
 import { Heading, HeadingSection } from '@wpmedia/arc-themes-components';
 
 const SectionBlockFeature = () => (
-  <HeadingSection>
-    <Heading>Latest Stories</Heading>
-    <HeadingSection>
-      <Heading>Save the clock tower</Heading>
-      <p>...</p>
-      <Heading>Mayor voting this Friday</Heading>
-      <p>...</p>
-    </HeadingSection>
-  </HeadingSection>
+	<HeadingSection>
+		<Heading>Latest Stories</Heading>
+		<HeadingSection>
+			<Heading>Save the clock tower</Heading>
+			<p>...</p>
+			<Heading>Mayor voting this Friday</Heading>
+			<p>...</p>
+		</HeadingSection>
+	</HeadingSection>
 )
 ```
 
@@ -81,25 +81,25 @@ const SectionBlockFeature = () => (
 
 ** Nested Headings **
 <Preview>
-  <Story name="Nested Headings">
+	<Story name="Nested Headings">
 		<Heading>Heading Level 1</Heading>
-    <HeadingSection>
-      <Heading>Heading Level 2</Heading>
-      <HeadingSection>
-        <Heading>Heading Level 3</Heading>
-        <HeadingSection>
-          <Heading>Heading Level 4</Heading>
-          <HeadingSection>
-            <Heading>Heading Level 5</Heading>
-            <HeadingSection>
-              <Heading>Heading Level 6</Heading>
+		<HeadingSection>
+			<Heading>Heading Level 2</Heading>
+			<HeadingSection>
+				<Heading>Heading Level 3</Heading>
+				<HeadingSection>
+					<Heading>Heading Level 4</Heading>
+					<HeadingSection>
+						<Heading>Heading Level 5</Heading>
+						<HeadingSection>
+							<Heading>Heading Level 6</Heading>
 							<HeadingSection>
-              	<Heading>Heading Level 6 Max</Heading>
-            	</HeadingSection>
-            </HeadingSection>
-          </HeadingSection>
-        </HeadingSection>
-      </HeadingSection>
-    </HeadingSection>
-  </Story>
+								<Heading>Heading Level 6 Max</Heading>
+							</HeadingSection>
+						</HeadingSection>
+					</HeadingSection>
+				</HeadingSection>
+			</HeadingSection>
+		</HeadingSection>
+	</Story>
 </Preview>

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -15,19 +15,17 @@ Headings should always:
 * be used in order
 * never skip levels when inceasing in numeric value
 
+Always use the `<Heading>` component in a block that you wish to make an HTML heading. The component will use the correct heading element from 1 to 6 depending on location.
+
+By default, this will output as `<h1>` if used on its own within a page. To ensure corrent hierarchy, please use `<HeadingSection>`.
+
+The `<HeadingSection>` component should be used to wrap all `<Heading>` components that should not be the page title. The `<HeadingSection>` component will increase the heading element value each time it is used. If you are making a feature that has a heading to be output as a title for a group of stories, then using the `<HeadingSection>` will increase the `<Heading>` items for you providing you correct hierarchy output of headings.
+
+In addition, the `<Heading>` component is customizable because custom classes can be passed in via `additionalClassNames` prop.
+
 ## Usage
 
 ### Heading
-
-<Props of={Heading} />
-
-Always use the `<Heading>` component in a block that you wish to make an HTML heading.
-
-The component will use the correct heading element from 1 to 6 depending on location.
-
-By default, this will output as `<h1>` if used on its own within a page. To ensure corrent hierarchy ensure the use of `<HeadingSection>` is used.
-
-In addition, the Heading component is customizable because custom classes can be passed in via `additionalClassNames` prop.
 
 ```jsx
 import { Heading } from '@wpmedia/arc-themes-components';
@@ -37,13 +35,7 @@ const BlockFeature = () => (
 )
 ```
 
-### HeadingSection
-
-<Props of={HeadingSection} />
-
-The `<HeadingSection>` component should be used to wrap all `<Heading>` components that should not be the page title.
-
-The `<HeadingSection>` component will increase the heading element value each time it is used. If you are making a feature that has a heading to be output as a title for a group of stories then using the `<HeadingSection>` will increase the `<Heading>` items for you providing you correct hierarchy output of headings.
+### Heading Section
 
 ```jsx
 import { Heading, HeadingSection } from '@wpmedia/arc-themes-components';
@@ -63,7 +55,13 @@ const SectionBlockFeature = () => (
 
 ## Properties
 
+### Heading
+
 <Props of={Heading} />
+
+### Heading Section
+
+<Props of={HeadingSection} />
 
 ## Stories
 

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -1,0 +1,107 @@
+import { Meta, Story, Preview, Props } from '@storybook/addon-docs';
+
+import Heading from './heading';
+import HeadingSection from './section';
+
+<Meta title="Components/Heading" component={Heading} />
+
+# Headings
+
+A set of components (`<Heading>` and `<HeadingSection>`) to allow control of headings to maintain their hierarchy within a page. Used together, the Themes Components are accessible if they are used together. Properly ordered headings make it easier for people using assistive technologies to navigate and comprehend the content.
+
+Headings (`<h1>` -> `<h6>`) are not to be used to achieve styling goals. They are to be used to provide semantic meaning and structure to a web page. Heading level maxes out at level 6.
+
+Headings should always:
+* be used in order
+* never skip levels when inceasing in numeric value
+
+## Usage
+
+### Heading
+
+<Props of={Heading} />
+
+Always use the `<Heading>` component in a block that you wish to make an HTML heading.
+
+The component will use the correct heading element from 1 to 6 depending on location.
+
+By default, this will output as `<h1>` if used on its own within a page. To ensure corrent hierarchy ensure the use of `<HeadingSection>` is used.
+
+In addition, the Heading component is customizable because custom classes can be passed in via `additionalClassNames` prop.
+
+```jsx
+import { Heading } from '@wpmedia/arc-themes-components';
+
+const BlockFeature = () => (
+  <Heading>Heading Children</Heading>
+)
+```
+
+### HeadingSection
+
+<Props of={HeadingSection} />
+
+The `<HeadingSection>` component should be used to wrap all `<Heading>` components that should not be the page title.
+
+The `<HeadingSection>` component will increase the heading element value each time it is used. If you are making a feature that has a heading to be output as a title for a group of stories then using the `<HeadingSection>` will increase the `<Heading>` items for you providing you correct hierarchy output of headings.
+
+```jsx
+import { Heading, HeadingSection } from '@wpmedia/arc-themes-components';
+
+const SectionBlockFeature = () => (
+  <HeadingSection>
+    <Heading>Latest Stories</Heading>
+    <HeadingSection>
+      <Heading>Save the clock tower</Heading>
+      <p>...</p>
+      <Heading>Mayor voting this Friday</Heading>
+      <p>...</p>
+    </HeadingSection>
+  </HeadingSection>
+)
+```
+
+## Properties
+
+<Props of={Heading} />
+
+## Stories
+
+** Heading **
+<Preview>
+	<Story name="Heading">
+		<Heading>Heading Level 1</Heading>
+	</Story>
+</Preview>
+
+** Heading With Custom Additional Classes **
+<Preview>
+	<Story name="Heading With Custom Additional Classes">
+		<Heading additionalClassNames="test-class test-class-1">Heading Level 1</Heading>
+	</Story>
+</Preview>
+
+** Nested Headings **
+<Preview>
+  <Story name="Nested Headings">
+		<Heading>Heading Level 1</Heading>
+    <HeadingSection>
+      <Heading>Heading Level 2</Heading>
+      <HeadingSection>
+        <Heading>Heading Level 3</Heading>
+        <HeadingSection>
+          <Heading>Heading Level 4</Heading>
+          <HeadingSection>
+            <Heading>Heading Level 5</Heading>
+            <HeadingSection>
+              <Heading>Heading Level 6</Heading>
+							<HeadingSection>
+              	<Heading>Heading Level 6 Max</Heading>
+            	</HeadingSection>
+            </HeadingSection>
+          </HeadingSection>
+        </HeadingSection>
+      </HeadingSection>
+    </HeadingSection>
+  </Story>
+</Preview>

--- a/src/components/headings/index.test.jsx
+++ b/src/components/headings/index.test.jsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+
+import Heading from './heading';
+import HeadingSection from './section';
+
+describe('Heading', () => {
+	it('should render as an h1 by default', () => {
+		render(<Heading>Hello World</Heading>);
+		const headingOutput = screen.getByRole('heading', { level: 1, name: 'Hello World' });
+		expect(headingOutput).toHaveClass('c-heading');
+	});
+	it('should render additional classes', () => {
+		render(<Heading additionalClassNames="test-class">Hello World</Heading>);
+		const headingOutput = screen.getByRole('heading', { level: 1, name: 'Hello World' });
+		expect(headingOutput).toHaveClass('c-heading test-class');
+	});
+});
+
+describe('HeadingSection', () => {
+	it('should render as a h2 when wrapping heading', () => {
+		render(
+			<HeadingSection>
+				<Heading />
+			</HeadingSection>,
+		);
+
+		const headingOutput = screen.getByRole('heading', { level: 2 });
+		expect(headingOutput).not.toBeNull();
+	});
+	it('increases the heading level for each HeadingSection until level 6', () => {
+		render(
+			<div>
+				<Heading>h1 text</Heading>
+				<HeadingSection>
+					<Heading>h2 text</Heading>
+					<HeadingSection>
+						<Heading>h3 text</Heading>
+						<HeadingSection>
+							<Heading>h4 text</Heading>
+							<HeadingSection>
+								<Heading>h5 text</Heading>
+								<HeadingSection>
+									<Heading>h6 text</Heading>
+									<HeadingSection>
+										{/* level 7 but max level 6 per heading logic */}
+										<Heading>h6 text level 7</Heading>
+									</HeadingSection>
+								</HeadingSection>
+							</HeadingSection>
+						</HeadingSection>
+					</HeadingSection>
+				</HeadingSection>
+			</div>,
+		);
+
+		const headingOutputLevelOne = screen.getByRole('heading', { level: 1, name: 'h1 text' });
+		expect(headingOutputLevelOne).not.toBeNull();
+
+		const headingOutputLevelTwo = screen.getByRole('heading', { level: 2, name: 'h2 text' });
+		expect(headingOutputLevelTwo).not.toBeNull();
+
+		const headingOutputLevelThree = screen.getByRole('heading', { level: 3, name: 'h3 text' });
+		expect(headingOutputLevelThree).not.toBeNull();
+
+		const headingOutputLevelFour = screen.getByRole('heading', { level: 4, name: 'h4 text' });
+		expect(headingOutputLevelFour).not.toBeNull();
+
+		const headingOutputLevelFive = screen.getByRole('heading', { level: 5, name: 'h5 text' });
+		expect(headingOutputLevelFive).not.toBeNull();
+
+		const headingOutputLevelSix = screen.getByRole('heading', { level: 6, name: 'h6 text' });
+		expect(headingOutputLevelSix).not.toBeNull();
+
+		const headingOutputLevelSeven = screen.getByRole('heading', { level: 6, name: 'h6 text level 7' });
+		expect(headingOutputLevelSeven).not.toBeNull();
+	});
+});

--- a/src/components/headings/section/index.jsx
+++ b/src/components/headings/section/index.jsx
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+import LevelContext from '../context';
+
+const HeadingSection = ({ children }) => (
+	<LevelContext.Consumer>
+		{(level) => (
+			<LevelContext.Provider value={level + 1}>
+				{children}
+			</LevelContext.Provider>
+		)}
+	</LevelContext.Consumer>
+);
+
+HeadingSection.propTypes = {
+	/** The text, images or any node that will be displayed within the component */
+	children: PropTypes.node.isRequired,
+};
+
+export default HeadingSection;


### PR DESCRIPTION
# Summary 

Add headings based on existing implementation and usage 

ticket: https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-657&assignee=5e387d6a1b1d910e5dfd7a9b

# AC 

Acceptance Criteria
Have the ability to render a heading HTML element using a <Heading> component

Provide the ability to section areas in order to increase <Heading> level using an <HeadingSection> component 

Have Scss file that adds the hooks to the Sass library

Have test coverage

Have storybook documentation

# Test 

1. `npm run storybook`
2. See properties shown for both components 
3. See explanation for usage of each component 
4. Include additional classes story 

# Questions 
- Style hooks do not include font family selection, right? This will be handled with tokens and inheritance 
- The children prop is ok using more generic node rather than string specifically because we could ingest other nodes, not just strings. Do we think that that is intended? 
- I initially included the components in separate folders. But then integrated them into one as the tests were interdependent. I noticed that the previous implementation also did this. I think this works well. what do you think? They're still exported as expected 