### PR TITLE
Refactor additionalClassnames to use className

### DIFF
--- a/_templates/component/new/default-entry.ejs.t
+++ b/_templates/component/new/default-entry.ejs.t
@@ -5,15 +5,15 @@ import PropTypes from 'prop-types';
 
 const COMPONENT_CLASS_NAME = 'c-<%= h.inflection.dasherize(component_name) %>';
 
-const <%= h.changeCase.pascal(component_name) %> = ({ children, additionalClassNames = '' }) => (
-	<div className={`${COMPONENT_CLASS_NAME} ${additionalClassNames}`}>
+const <%= h.changeCase.pascal(component_name) %> = ({ children, className }) => (
+	<div className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}>
 		{children}
 	</div>
 );
 
 <%= h.changeCase.pascal(component_name) %>.propTypes = {
-	/** Class name(s) that get appended to default class name of the component */
-	additionalClassNames: PropTypes.string,
+	/** Class Name(s) will be appended to the default class name we apply to the specific component. */
+	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
 	children: PropTypes.node.isRequired,
 };

--- a/_templates/component/new/default-entry.ejs.t
+++ b/_templates/component/new/default-entry.ejs.t
@@ -12,7 +12,7 @@ const <%= h.changeCase.pascal(component_name) %> = ({ children, className }) => 
 );
 
 <%= h.changeCase.pascal(component_name) %>.propTypes = {
-	/** Class Name(s) will be appended to the default class name we apply to the specific component. */
+	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
 	children: PropTypes.node.isRequired,

--- a/src/components/headings/heading/index.jsx
+++ b/src/components/headings/heading/index.jsx
@@ -3,12 +3,10 @@ import LevelContext from "../context";
 
 const COMPONENT_CLASS_NAME = "c-heading";
 
-const Heading = ({ additionalClassNames = "", children }) => (
+const Heading = ({ className, children }) => (
 	<LevelContext.Consumer>
 		{(level) => {
-			const allClasses = `${COMPONENT_CLASS_NAME}${
-				additionalClassNames ? ` ${additionalClassNames}` : ""
-			}`;
+			const allClasses = `${COMPONENT_CLASS_NAME}${className ? ` ${className}` : ""}`;
 			// max heading level is 6
 			const HeadingTag = `h${Math.min(level, 6)}`;
 
@@ -19,7 +17,7 @@ const Heading = ({ additionalClassNames = "", children }) => (
 
 Heading.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
-	additionalClassNames: PropTypes.string,
+	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
 	children: PropTypes.node.isRequired,
 };

--- a/src/components/headings/heading/index.jsx
+++ b/src/components/headings/heading/index.jsx
@@ -6,11 +6,16 @@ const COMPONENT_CLASS_NAME = "c-heading";
 const Heading = ({ className, children }) => (
 	<LevelContext.Consumer>
 		{(level) => {
-			const allClasses = `${COMPONENT_CLASS_NAME}${className ? ` ${className}` : ""}`;
 			// max heading level is 6
 			const HeadingTag = `h${Math.min(level, 6)}`;
 
-			return <HeadingTag className={allClasses}>{children}</HeadingTag>;
+			return (
+				<HeadingTag
+					className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
+				>
+					{children}
+				</HeadingTag>
+			);
 		}}
 	</LevelContext.Consumer>
 );

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -22,7 +22,7 @@ By default, this will output as `<h1>` if used on its own within a page. To ensu
 
 The `<HeadingSection>` component should be used to wrap all `<Heading>` components that should not be the page title. The `<HeadingSection>` component will increase the heading element value each time it is used. If you are making a feature that has a heading to be output as a title for a group of stories, then using the `<HeadingSection>` will increase the `<Heading>` items for you providing you correct hierarchy output of headings.
 
-In addition, the `<Heading>` component is customizable because custom classes can be passed in via `additionalClassNames` prop.
+In addition, the `<Heading>` component is customizable because custom classes can be passed in via the `className` prop which we will append to a class name we already provide for the Heading.
 
 ## Usage
 

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -22,7 +22,7 @@ By default, this will output as `<h1>` if used on its own within a page. To ensu
 
 The `<HeadingSection>` component should be used to wrap all `<Heading>` components that should not be the page title. The `<HeadingSection>` component will increase the heading element value each time it is used. If you are making a feature that has a heading to be output as a title for a group of stories, then using the `<HeadingSection>` will increase the `<Heading>` items for you providing you correct hierarchy output of headings.
 
-In addition, the `<Heading>` component is customizable because custom classes can be passed in via the `className` prop which we will append to a class name we already provide for the Heading.
+In addition, the `<Heading>` component is customizable because custom classes can be passed in via the `className` prop which we will appended to a class name we already provide for the Heading.
 
 ## Usage
 

--- a/src/components/headings/index.test.jsx
+++ b/src/components/headings/index.test.jsx
@@ -13,7 +13,7 @@ describe("Heading", () => {
 		expect(headingOutput).toHaveClass("c-heading");
 	});
 	it("should render additional classes", () => {
-		render(<Heading additionalClassNames="test-class">Hello World</Heading>);
+		render(<Heading className="test-class">Hello World</Heading>);
 		const headingOutput = screen.getByRole("heading", {
 			level: 1,
 			name: "Hello World",

--- a/src/components/headings/index.test.jsx
+++ b/src/components/headings/index.test.jsx
@@ -26,7 +26,7 @@ describe("HeadingSection", () => {
 	it("should render as a h2 when wrapping heading", () => {
 		render(
 			<HeadingSection>
-				<Heading />
+				<Heading>Heading Text</Heading>
 			</HeadingSection>
 		);
 

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-no-target-blank */
 import PropTypes from "prop-types";
 
+const COMPONENT_CLASS_NAME = "c-link";
+
 function determineVisuallyHiddenText(supplementalText, opensInNewTab) {
 	if (supplementalText) {
 		return supplementalText;
@@ -23,7 +25,7 @@ const Link = ({ assistiveHidden, children, className, href, openInNewTab, supple
 
 	return (
 		<a
-			className={`c-link${className ? ` ${className}` : ""}`}
+			className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
 			href={href}
 			aria-hidden={assistiveHidden ? "true" : undefined}
 			tabIndex={assistiveHidden ? "-1" : undefined}

--- a/src/components/link/index.jsx
+++ b/src/components/link/index.jsx
@@ -13,27 +13,17 @@ function determineVisuallyHiddenText(supplementalText, opensInNewTab) {
 	return "";
 }
 
-const Link = ({
-	additionalClassNames,
-	assistiveHidden,
-	children,
-	href,
-	openInNewTab,
-	supplementalText,
-}) => {
+const Link = ({ assistiveHidden, children, className, href, openInNewTab, supplementalText }) => {
 	// openInNewTab is undefined by default
 	// http or https link or openInNewTab can be either true or undefined for opening in new tab
 	const opensInNewTab =
 		(href.startsWith("http") && openInNewTab !== false) || openInNewTab === true;
-	const defaultAndAdditionalClassnames = `c-link${
-		additionalClassNames ? ` ${additionalClassNames}` : ""
-	}`;
 
 	const visuallyHiddenText = determineVisuallyHiddenText(supplementalText, opensInNewTab);
 
 	return (
 		<a
-			className={defaultAndAdditionalClassnames}
+			className={`c-link${className ? ` ${className}` : ""}`}
 			href={href}
 			aria-hidden={assistiveHidden ? "true" : undefined}
 			tabIndex={assistiveHidden ? "-1" : undefined}
@@ -48,7 +38,7 @@ const Link = ({
 
 Link.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
-	additionalClassNames: PropTypes.string,
+	className: PropTypes.string,
 	/** Remove the link from the accessibility tree with aria-hidden, tabindex=-1 */
 	assistiveHidden: PropTypes.bool,
 	/** The text, images or any node that will be displayed within the link */
@@ -65,7 +55,7 @@ Link.propTypes = {
 };
 
 Link.defaultProps = {
-	additionalClassNames: "",
+	className: "",
 	assistiveHidden: false,
 	openInNewTab: undefined,
 	supplementalText: "",

--- a/src/components/link/index.test.jsx
+++ b/src/components/link/index.test.jsx
@@ -58,7 +58,7 @@ describe("Link", () => {
 	});
 	it("should take in additional classnames", () => {
 		render(
-			<Link href={EXTERNAL_LINK_DESTINATION} additionalClassNames="test-class">
+			<Link href={EXTERNAL_LINK_DESTINATION} className="test-class">
 				{LINK_TEXT}
 			</Link>
 		);


### PR DESCRIPTION
Per our conversation in Slack:
https://washpost.slack.com/archives/C01HPGGMJM6/p1645740739179659

Utilize the conventional `className` property for dealing with classification of elements.

1. Pull down branch `git checkout additionalClassNames-refactor`
2. Run `npm run test` and validate 100% status
3. Run `npm run storybook` and check the documentation for the update
![image](https://user-images.githubusercontent.com/2287238/155620786-78e57bd7-abeb-4c6a-b80e-e693c3e1455a.png)
