### PR TITLE
LINTING improvement: Update linting to enforce new jsx runtime 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 		es6: true,
 		jest: true,
 	},
-	extends: ["airbnb", "prettier"],
+	extends: ["airbnb", "plugin:react/jsx-runtime", "prettier"],
 	globals: {
 		Atomics: "readonly",
 		SharedArrayBuffer: "readonly",

--- a/src/components/paragraph/index.jsx
+++ b/src/components/paragraph/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import PropTypes from "prop-types";
 
 const Paragraph = ({ children }) => <p className="c-paragraph">{children}</p>;

--- a/src/components/paragraph/index.test.jsx
+++ b/src/components/paragraph/index.test.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import renderer from "react-test-renderer";
 import Paragraph from ".";
 


### PR DESCRIPTION
Noticed some linting that wasn't being done programmatically https://github.com/WPMedia/arc-themes-components/pull/25#discussion_r814849642

This would ensure the correct imports are being used as well as ensure no unnecessary react imports are used as well with the new jsx runtime we're using 

https://github.com/WPMedia/arc-themes-components/pull/25#discussion_r814852671

