### PR TITLE
TMEDIA-668: date component without formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 /* eslint import/order: ["error", {"alphabetize": {"order": "asc", "caseInsensitive": true}}] */
 // inject imports after this comment and alphabetize them
+import Date from "./src/components/date";
 import Heading from "./src/components/headings/heading";
 import HeadingSection from "./src/components/headings/section";
 import Link from "./src/components/link";
 import Paragraph from "./src/components/paragraph";
 import Stack from "./src/components/stack";
 
-export { Heading, HeadingSection, Link, Paragraph, Stack };
+export { Date, Heading, HeadingSection, Link, Paragraph, Stack };

--- a/scss.scss
+++ b/scss.scss
@@ -5,3 +5,4 @@
 @use "./src/components/headings";
 
 @use "./src/components/stack";
+@use "./src/components/date";

--- a/src/components/date/_index.scss
+++ b/src/components/date/_index.scss
@@ -1,0 +1,5 @@
+@use "../../scss";
+
+.c-date {
+	@include scss.component-properties("date");
+}

--- a/src/components/date/index.jsx
+++ b/src/components/date/index.jsx
@@ -16,7 +16,10 @@ Date.propTypes = {
 	className: PropTypes.string,
 	/** The human-readable text that will be displayed within the component */
 	dateString: PropTypes.string.isRequired,
-	/** The date and time of the dateString passed in. This must be a valid machine-readable datetime value */
+	/**
+	 * The date and time of the dateString passed in. This must be a valid machine-readable datetime value
+	 * This value should be in an ISO 8601 format.
+	 */
 	dateTime: PropTypes.string.isRequired,
 };
 

--- a/src/components/date/index.jsx
+++ b/src/components/date/index.jsx
@@ -2,17 +2,22 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-date";
 
-const Date = ({ children, className }) => (
-	<div className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}>
-		{children}
-	</div>
+const Date = ({ className, dateString, dateTime }) => (
+	<time
+		className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
+		dateTime={dateTime}
+	>
+		{dateString}
+	</time>
 );
 
 Date.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
-	/** The text, images or any node that will be displayed within the component */
-	children: PropTypes.node.isRequired,
+	/** The human-readable text that will be displayed within the component */
+	dateString: PropTypes.string.isRequired,
+	/** The date and time of the dateString passed in. This must be a valid machine-readable datetime value */
+	dateTime: PropTypes.string.isRequired,
 };
 
 export default Date;

--- a/src/components/date/index.jsx
+++ b/src/components/date/index.jsx
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+
+const COMPONENT_CLASS_NAME = "c-date";
+
+const Date = ({ children, className }) => (
+	<div className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}>
+		{children}
+	</div>
+);
+
+Date.propTypes = {
+	/** Class name(s) that get appended to default class name of the component */
+	className: PropTypes.string,
+	/** The text, images or any node that will be displayed within the component */
+	children: PropTypes.node.isRequired,
+};
+
+export default Date;

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -59,7 +59,7 @@ const DateFeature = () => <Date dateTime="2018-03-05" dateString="March 5" />;
 	<Story name="Date and Time with no timezone">
 		<p>
 			Last Christmas <Date dateTime="2018-12-25T07:00:00" dateString="December 25 at 7 am" />,
-			presents will be opened across the world!
+			presents will be opened in many places across the world!
 		</p>
 	</Story>
 </Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -6,14 +6,16 @@ import Date from ".";
 
 # Date
 
-The `<Date>` component is used to display a date string (human-readable format) and datetime (machine-readable).
+The `<Date>` component is used to display a date string (human-readable format) and datetime (machine-readable). The `datetime` property can be used in alignment with browsers and other tools to integrate date and time.
+
+The datetime should be a valid ISO 8601 date string. In this way, the date and time can be handled in a uniform way across timezones. For more information on valid datetime values, [see MDN doc](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values).
 
 ## Usage
 
 ```jsx
 import { Date } from "@wpmedia/arc-themes-components";
 
-const DateFeature = () => <Date dateTime="2018-07-07" dateString="July 7" />;
+const DateFeature = () => <Date dateTime="2018-03-05" dateString="March 5" />;
 ```
 
 ## Properties
@@ -22,10 +24,21 @@ const DateFeature = () => <Date dateTime="2018-07-07" dateString="July 7" />;
 
 ## Stories
 
-** Default **
+** Date **
 
 <Preview>
-	<Story name="Default">
-		<Date dateTime="2018-07-07" dateString="July 7" />
+	<Story name="Date">
+		<Date dateTime="2018-03-05" dateString="March 5" />
+	</Story>
+</Preview>
+
+** Date and Time **
+
+<Preview>
+	<Story name="Date and Time">
+		<p>
+			The concert starts at{" "}
+			<Date datetime="2018-03-05T20:00:00" dateString="March 5 at 8 at night" />.
+		</p>
 	</Story>
 </Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -6,15 +6,14 @@ import Date from ".";
 
 # Date
 
---- Add a description of the component here ---
+The `<Date>` component is used to display a date string (human-readable format) and datetime (machine-readable).
 
 ## Usage
 
-```
-import { Date } from '@wpmedia/arc-themes-components';
+```jsx
+import { Date } from "@wpmedia/arc-themes-components";
 
-
-<Date>Component Children</Date>
+const DateFeature = () => <Date dateTime="2018-07-07" dateString="July 7" />;
 ```
 
 ## Properties
@@ -27,6 +26,6 @@ import { Date } from '@wpmedia/arc-themes-components';
 
 <Preview>
 	<Story name="Default">
-		<Date>Date Text</Date>
+		<Date dateTime="2018-07-07" dateString="July 7" />
 	</Story>
 </Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -59,7 +59,7 @@ const DateFeature = () => <Date dateTime="2018-03-05" dateString="March 5" />;
 	<Story name="Date and Time with no timezone">
 		<p>
 			Last Christmas <Date dateTime="2018-12-25T07:00:00" dateString="December 25 at 7 am" />,
-			presents will be opened in many places across the world!
+			presents were opened in many places across the world!
 		</p>
 	</Story>
 </Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -38,7 +38,7 @@ const DateFeature = () => <Date dateTime="2018-03-05" dateString="March 5" />;
 	<Story name="Date and Time">
 		<p>
 			The concert starts at{" "}
-			<Date datetime="2018-03-05T20:00:00" dateString="March 5 at 8 at night" />.
+			<Date dateTime="2018-03-05T20:00:00" dateString="March 5 at 8 at night" />.
 		</p>
 	</Story>
 </Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -1,0 +1,32 @@
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs";
+
+import Date from ".";
+
+<Meta title="Components/Date" component={Date} />
+
+# Date
+
+--- Add a description of the component here ---
+
+## Usage
+
+```
+import { Date } from '@wpmedia/arc-themes-components';
+
+
+<Date>Component Children</Date>
+```
+
+## Properties
+
+<Props of={Date} />
+
+## Stories
+
+** Default **
+
+<Preview>
+	<Story name="Default">
+		<Date>Date Text</Date>
+	</Story>
+</Preview>

--- a/src/components/date/index.stories.mdx
+++ b/src/components/date/index.stories.mdx
@@ -42,3 +42,24 @@ const DateFeature = () => <Date dateTime="2018-03-05" dateString="March 5" />;
 		</p>
 	</Story>
 </Preview>
+
+** Time Only **
+
+<Preview>
+	<Story name="Time Only">
+		<p>
+			Every day at <Date dateTime="20:00:00" dateString="8" />, the show will be on.
+		</p>
+	</Story>
+</Preview>
+
+** Date and Time with no timezone **
+
+<Preview>
+	<Story name="Date and Time with no timezone">
+		<p>
+			Last Christmas <Date dateTime="2018-12-25T07:00:00" dateString="December 25 at 7 am" />,
+			presents will be opened across the world!
+		</p>
+	</Story>
+</Preview>

--- a/src/components/date/index.test.jsx
+++ b/src/components/date/index.test.jsx
@@ -3,8 +3,26 @@ import { render, screen } from "@testing-library/react";
 import Date from ".";
 
 describe("Date", () => {
-	it("should render string child", () => {
-		render(<Date>Hello World</Date>);
-		expect(screen.queryByText("Hello World")).not.toBeNull();
+	it("should render date string", () => {
+		render(<Date dateTime="2018-03-05T20:00:00" dateString="March 5 at 8 at night" />);
+		const foundDate = screen.queryByText("March 5 at 8 at night");
+
+		expect(foundDate).not.toBeNull();
+		expect(foundDate).toHaveClass("c-date");
+		expect(foundDate).toHaveAttribute("datetime", "2018-03-05T20:00:00");
+	});
+	it("should have additional classes", () => {
+		render(
+			<Date
+				dateTime="2018-03-05T20:00:00"
+				dateString="March 5 at 8 at night"
+				className="test-class"
+			/>
+		);
+		const foundDate = screen.queryByText("March 5 at 8 at night");
+
+		expect(foundDate).not.toBeNull();
+		expect(foundDate).toHaveClass("c-date test-class");
+		expect(foundDate).toHaveAttribute("datetime", "2018-03-05T20:00:00");
 	});
 });

--- a/src/components/date/index.test.jsx
+++ b/src/components/date/index.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+
+import Date from ".";
+
+describe("Date", () => {
+	it("should render string child", () => {
+		render(<Date>Hello World</Date>);
+		expect(screen.queryByText("Hello World")).not.toBeNull();
+	});
+});


### PR DESCRIPTION
Ticket: https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-668&assignee=5e387d6a1b1d910e5dfd7a9b

# AC

Acceptance Criteria
Create a <Date> component

Using HTML <time> element as output

Required datetime attribute on the element

Input date prop is an ISO format

Input date text is a string

Have Scss file that adds the hooks to the Sass library

Have test coverage

Have storybook documentation

# Test 

1. `npm run storybook`
2. See description along with description of iso 
3. See usages of how the component could work in the docs tab
4.  See two examples of iso 8061 dates shown in the Canvas tab including date and a date and time

# Questions 

- the `<time>` element can take in intervals as well as time on a 24-hour clock. But this didn't seem like part of our usage in the blocks. Do you want me to include examples? 
- I used camelCase for dateTime prop passed in. This seemed in line with react prop naming rather than the html `datetime`
- I used the `dateString` rather than children based on the requirements. This is what we want, right? seems to make sense to me for our current usages

