### PR TITLE
Update inline prop on Stack to remove errors

### DIFF
--- a/src/components/stack/index.stories.mdx
+++ b/src/components/stack/index.stories.mdx
@@ -89,7 +89,7 @@ import { Stack } from '@wpmedia/arc-themes-components';
 
 <Preview>
 	<Story name="Vertical with divider and inlined">
-		<Stack divider inline="true">
+		<Stack divider inline>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "blue" }}> </div>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "red" }}> </div>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "brown" }}> </div>
@@ -231,7 +231,7 @@ import { Stack } from '@wpmedia/arc-themes-components';
 
 <Preview>
 	<Story name="Horizontal with no wrap and inlined">
-		<Stack direction="horizontal" wrap="nowrap" inline="true">
+		<Stack direction="horizontal" wrap="nowrap" inline>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "blue" }}> </div>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "red" }}> </div>
 			<div style={{ height: "250px", width: "250px", backgroundColor: "blue" }}> </div>

--- a/src/components/stack/index.test.jsx
+++ b/src/components/stack/index.test.jsx
@@ -299,7 +299,7 @@ describe("Stack", () => {
 
 	it("should render an inline container when specified", () => {
 		const { container } = render(
-			<Stack inline="true">
+			<Stack inline>
 				<div style={{ height: "100px", width: "200px" }}>
 					<img alt="image 1" src="https://picsum.photos/200/100" />
 				</div>


### PR DESCRIPTION
`inline` prop is a boolean and generates console errors if not passed an a boolean. 

<img width="846" alt="Visual Studio Code-2022-03-02-09-41 59" src="https://user-images.githubusercontent.com/868127/156336473-fbee61b2-93ec-44b7-b921-8c09cb758c2c.png">
