### PR TITLE
Fix duplicate CSS for secondary-reverse, add medium hooks

### DIFF
--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -39,6 +39,10 @@
 		@include scss.component-properties("button-full-width");
 	}
 
+	&--default {
+		@include scss.component-with-states("button-default", [hover, active]);
+	}
+
 	&--primary {
 		@include scss.component-with-states("button-primary", [hover, active]);
 	}

--- a/src/components/button/_index.scss
+++ b/src/components/button/_index.scss
@@ -4,6 +4,7 @@
 	-webkit-appearance: none;
 	align-items: center;
 	display: inline-flex;
+	height: max-content;
 
 	@include scss.component-properties("button");
 
@@ -46,8 +47,8 @@
 		@include scss.component-with-states("button-primary-reverse", [hover, active]);
 	}
 
-	&--secondary-reverse {
-		@include scss.component-with-states("button-secondary-reverse", [hover, active]);
+	&--secondary {
+		@include scss.component-with-states("button-secondary", [hover, active]);
 	}
 
 	&--secondary-reverse {
@@ -56,6 +57,10 @@
 
 	&--small {
 		@include scss.component-with-states("button-small", [hover, active]);
+	}
+
+	&--medium {
+		@include scss.component-with-states("button-medium", [hover, active]);
 	}
 
 	&--large {

--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -64,9 +64,10 @@ const Button = forwardRef((props, ref) => {
 });
 
 Button.defaultProps = {
-	type: "button",
-	size: "medium",
 	fullWidth: false,
+	size: "medium",
+	type: "button",
+	variant: "default",
 };
 
 Button.propTypes = {


### PR DESCRIPTION
## Description

* Fix and issue where this a duplicated `secondary-reverse` CSS property
* Added CSS property and Sass include for medium buttons
* Added `height: max-content` to ensure when button is used in a stack it does not fill height of parent

## Acceptance Criteria

_copy from ticket_

## Test Steps

1. Checkout branch - `git checkout button-fixes`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
