### PR TITLE
REFACTOR small improvement: Style use helper state mixin

### DIFF
--- a/src/components/attribution/_index.scss
+++ b/src/components/attribution/_index.scss
@@ -4,18 +4,6 @@
 	@include scss.component-properties("attribution");
 
 	a {
-		@include scss.component-properties("attribution-link");
-
-		&:hover {
-			@include scss.component-properties("attribution-link-hover");
-		}
-
-		&:active {
-			@include scss.component-properties("attribution-link-active");
-		}
-
-		&:visited {
-			@include scss.component-properties("attribution-link-visited");
-		}
+		@include scss.component-with-states("attribution-link", [hover, active, visited]);
 	}
 }

--- a/src/components/link/_index.scss
+++ b/src/components/link/_index.scss
@@ -1,17 +1,5 @@
 @use "../../scss";
 
 .c-link {
-	@include scss.component-properties("link");
-
-	&:hover {
-		@include scss.component-properties("link-hover");
-	}
-
-	&:active {
-		@include scss.component-properties("link-active");
-	}
-
-	&:visited {
-		@include scss.component-properties("link-visited");
-	}
+	@include scss.component-with-states("link", [hover, active, visited]);
 }

--- a/src/components/overline/_index.scss
+++ b/src/components/overline/_index.scss
@@ -1,21 +1,5 @@
 @use "../../scss";
 
 .c-overline {
-	@include scss.component-properties("overline");
-
-	&:hover {
-		@include scss.component-properties("overline-hover");
-	}
-
-	&:active {
-		@include scss.component-properties("overline-active");
-	}
-
-	&:visited {
-		@include scss.component-properties("overline-visited");
-	}
-
-	&:focus {
-		@include scss.component-properties("overline-focus");
-	}
+	@include scss.component-with-states("overline", [hover, active, visited, focus]);
 }

--- a/src/components/pill/_index.scss
+++ b/src/components/pill/_index.scss
@@ -1,21 +1,5 @@
 @use "../../scss";
 
 .c-pill {
-	@include scss.component-properties("pill");
-
-	&:hover {
-		@include scss.component-properties("pill-hover");
-	}
-
-	&:active {
-		@include scss.component-properties("pill-active");
-	}
-
-	&:visited {
-		@include scss.component-properties("pill-visited");
-	}
-
-	&:focus {
-		@include scss.component-properties("pill-focus");
-	}
+	@include scss.component-with-states("pill", [hover, active, visited, focus]);
 }


### PR DESCRIPTION
- Noticed the state mixin was used in some places and not others. It made sense to standardize the naming around this if this is the direction we're going
- Tested this by passing in different options to the storybook theme to ensure that the classes we're being generated as expected