### PR TITLE
fix: Fix typo "accessible" in docs

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -71,7 +71,7 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
-	/** Provide an accessbile name to the button - use only when the button itself does not have meaningful text content */
+	/** Provide an accessible name to the button - use only when the button itself does not have meaningful text content */
 	accessibilityLabel: PropTypes.string,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,


### PR DESCRIPTION
- Small typo I noticed in the props