### PR TITLE
TMEDIA-709 - video player

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,1 +1,1 @@
-<!-- .storybook/preview-head.html -->
+<script defer src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script>

--- a/.storybook/theme.scss
+++ b/.storybook/theme.scss
@@ -21,6 +21,9 @@
 					height: auto,
 					width: 1px,
 				),
+				video: (
+					background-color: #000000,
+				),
 			),
 		),
 	)

--- a/index.js
+++ b/index.js
@@ -17,12 +17,14 @@ import Separator from "./src/components/separator";
 import Stack from "./src/components/stack";
 import Video from "./src/components/video";
 import formatCredits from "./src/utils/format-credits";
+import formatPowaVideoEmbed from "./src/utils/format-powa-video-embed";
 
 export {
 	Attribution,
 	Button,
 	Date,
 	formatCredits,
+	formatPowaVideoEmbed,
 	Heading,
 	HeadingSection,
 	Icon,

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ import Paragraph from "./src/components/paragraph";
 import Pill from "./src/components/pill";
 import Separator from "./src/components/separator";
 import Stack from "./src/components/stack";
+import Video from "./src/components/video";
 import formatCredits from "./src/utils/format-credits";
 
 export {
@@ -34,4 +35,5 @@ export {
 	Pill,
 	Separator,
 	Stack,
+	Video,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12103,8 +12103,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -12711,7 +12710,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -13609,8 +13607,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -14635,7 +14632,6 @@
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.0.tgz",
       "integrity": "sha512-fDGekdaHh65eI3lMi5OnErU6a8Ighg2KjcjQxO7m8VHyWjcPyj5kiOgV1LQDOOOgVy3+5FgjXvdSSX7B8/5/4g==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15064,8 +15060,15 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-oembed-container": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-oembed-container/-/react-oembed-container-1.0.1.tgz",
+      "integrity": "sha512-wU7s2Ql6LZp7bTbf7Hloy7ONDCSb+44iM4Ezdk36qqsVSxOefvN70DBuqf3Z/c7zQdYVwODHryMYawq6sxmG+A==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
     },
     "react-popper": {
       "version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -85,5 +85,8 @@
     "stylelint-config-recommended": "^6.0.0",
     "stylelint-config-sass-guidelines": "^9.0.1",
     "stylelint-no-unsupported-browser-features": "^5.0.2"
+  },
+  "dependencies": {
+    "react-oembed-container": "^1.0.1"
   }
 }

--- a/scss.scss
+++ b/scss.scss
@@ -14,3 +14,4 @@
 @use "./src/components/attribution";
 @use "./src/components/input";
 @use "./src/components/pill";
+@use "./src/components/video";

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -1,20 +1,14 @@
 @use "../../scss";
 
 .c-video {
+	// first take in the default component aspect-ratio
+	// includes a fallback if no aspect ratio is specified
+	// default of 16:9 from engine-theme-sdk
+	--aspect-ratio: var(--c-video-aspect-ratio, 16 / 9);
+
 	@include scss.component-properties("video");
 
-	&--not-loaded {
-		@include scss.component-properties("video-not-loaded");
-
-		// viewport percentage is listed as being for vertical percentage
-		// this is how big the video is in the viewport
-		// using multiplication with vh so that when the css var is evaluated, it has a unit
-		padding-bottom: calc(var(--viewport-percentage, 65) * 1vh);
-
-		// using vh with width because the viewport percentage is based off of vertical percentage
-		// the aspect ratio is used so that the size respects the aspect ratio of the video
-
-		// default of 16:9 and 65 based on video player previous defaults
-		max-width: calc(var(--aspect-ratio, 16 / 9) * var(--viewport-percentage, 65) * 1vh);
-	}
+	aspect-ratio: var(--aspect-ratio);
+	// set default of 65 based on engine-theme-sdk
+	height: calc(var(--viewport-percentage, 65) * 1vh);
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -8,6 +8,7 @@
 
 		// viewport percentage is listed as being for vertical percentage
 		// this is how big the video is in the viewport
+		// using multiplication with vh so that when the css var is evaluated, it has a unit
 		padding-bottom: calc(var(--viewport-percentage) * 1vh);
 
 		// using vh with width because the viewport percentage is based off of vertical percentage

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -15,4 +15,6 @@
 	aspect-ratio: var(--aspect-ratio);
 	// convert to vh via * 1vh
 	height: calc(var(--height) * 1vh);
+
+	max-width: 100%;
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -6,9 +6,13 @@
 	// default of 16:9 from engine-theme-sdk
 	--aspect-ratio: var(--c-video-aspect-ratio, 16 / 9);
 
+	// height is used a percentage of the viewport per the requirements
+	// default of 65 from engine-theme-sdk
+	--height: var(--c-video-height, 65);
+
 	@include scss.component-properties("video");
 
 	aspect-ratio: var(--aspect-ratio);
-	// set default of 65 based on engine-theme-sdk
-	height: calc(var(--viewport-percentage, 65) * 1vh);
+	// convert to vh via * 1vh
+	height: calc(var(--height) * 1vh);
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -13,7 +13,8 @@
 
 		// using vh with width because the viewport percentage is based off of vertical percentage
 		// the aspect ratio is used so that the size respects the aspect ratio of the video
-		// default of 16:9 based on video player previous defaults
+
+		// default of 16:9 and 65 based on video player previous defaults
 		max-width: calc(var(--aspect-ratio, 16 / 9) * var(--viewport-percentage, 65) * 1vh);
 	}
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -1,0 +1,13 @@
+@use "../../scss";
+
+.c-video {
+	@include scss.component-properties("video");
+
+	&--not-loaded {
+		@include scss.component-properties("video-not-loaded");
+
+		// viewport percentage is listed as being for vertical percentage
+		// this is how big the video is in the viewport
+		padding-bottom: calc(calc(var(--viewport-percentage) / 100) * 100vh);
+	}
+}

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -9,10 +9,11 @@
 		// viewport percentage is listed as being for vertical percentage
 		// this is how big the video is in the viewport
 		// using multiplication with vh so that when the css var is evaluated, it has a unit
-		padding-bottom: calc(var(--viewport-percentage) * 1vh);
+		padding-bottom: calc(var(--viewport-percentage, 65) * 1vh);
 
 		// using vh with width because the viewport percentage is based off of vertical percentage
 		// the aspect ratio is used so that the size respects the aspect ratio of the video
-		max-width: calc(var(--aspect-ratio) * var(--viewport-percentage) * 1vh);
+		// default of 16:9 based on video player previous defaults
+		max-width: calc(var(--aspect-ratio, 16 / 9) * var(--viewport-percentage, 65) * 1vh);
 	}
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -8,6 +8,10 @@
 
 		// viewport percentage is listed as being for vertical percentage
 		// this is how big the video is in the viewport
-		padding-bottom: calc(calc(var(--viewport-percentage) / 100) * 100vh);
+		padding-bottom: calc(var(--viewport-percentage) * 1vh);
+
+		// using vh with width because the viewport percentage is based off of vertical percentage
+		// the aspect ratio is used so that the size respects the aspect ratio of the video
+		max-width: calc(var(--aspect-ratio) * var(--viewport-percentage) * 1vh);
 	}
 }

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -4,42 +4,7 @@ import EmbedContainer from "react-oembed-container";
 
 const COMPONENT_CLASS_NAME = "c-video";
 
-// simple util function
-function convertStringToNode(string) {
-	const parser = new DOMParser();
-	const doc = parser.parseFromString(string, "text/html");
-	// get the body, will return <body> around your code
-	return doc.body;
-}
-
-// taking in embed code
-// adding on any powa fields
-// todo: return the embed code with the correct statuses
-const getEmbedHTMLWithPlayStatus = (embedMarkup, aspectRatio, powaFields = {}) => {
-	if (embedMarkup) {
-		const embedHTMLWithPlayStatus = convertStringToNode(embedMarkup);
-
-		// set the rest of powa fields, minus aspect ratio
-		// https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/
-		const powaFieldEntries = Object.entries(powaFields);
-
-		// set aspect ratio
-		// flip the resolution to match implementation in powa height / width
-		embedHTMLWithPlayStatus
-			.querySelector(".powa")
-			.setAttribute("data-aspect-ratio", 1 / aspectRatio);
-
-		powaFieldEntries.forEach(([key, value]) => {
-			embedHTMLWithPlayStatus.querySelector(".powa").setAttribute(`data-${key}`, value);
-		});
-
-		// innerhtml ensures body tag not rendered
-		return embedHTMLWithPlayStatus.innerHTML;
-	}
-	return "";
-};
-
-const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, powaFields }) => {
+const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 	// only render or call powaboot on client-side
 	const isClientSide = typeof window !== "undefined";
 
@@ -62,10 +27,10 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, powaFi
 			}}
 		>
 			{isClientSide ? (
-				<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup, aspectRatio, powaFields)}>
+				<EmbedContainer markup={embedMarkup}>
 					<div
 						dangerouslySetInnerHTML={{
-							__html: getEmbedHTMLWithPlayStatus(embedMarkup, aspectRatio, powaFields),
+							__html: embedMarkup,
 						}}
 					/>
 				</EmbedContainer>

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -26,13 +26,16 @@ const getEmbedHTMLWithPlayStatus = (embedMarkup) => {
 };
 
 const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
+	// only render or call powaboot on client-side
+	const isClientSide = typeof window !== "undefined";
+
 	useEffect(() => {
 		// will only ever run client-side as window object not available on server
 		// if powaboot available, call it
-		if (window.powaBoot) {
+		if (isClientSide && window.powaBoot) {
 			window.powaBoot();
 		}
-	}, []);
+	}, [isClientSide]);
 
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
@@ -44,9 +47,11 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 				"--height": viewportPercentage,
 			}}
 		>
-			<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup)}>
-				<div dangerouslySetInnerHTML={{ __html: getEmbedHTMLWithPlayStatus(embedMarkup) }} />
-			</EmbedContainer>
+			{isClientSide ? (
+				<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup)}>
+					<div dangerouslySetInnerHTML={{ __html: getEmbedHTMLWithPlayStatus(embedMarkup) }} />
+				</EmbedContainer>
+			) : null}
 		</div>
 	);
 };

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -1,10 +1,33 @@
 import PropTypes from "prop-types";
+import EmbedContainer from "react-oembed-container";
 
 const COMPONENT_CLASS_NAME = "c-video";
 
-const Video = ({ className, aspectRatio, viewportPercentage }) => {
+// simple util function
+function convertStringToNode(string) {
+	const parser = new DOMParser();
+	const doc = parser.parseFromString(string, "text/html");
+	// get the body, will return <body> around your code
+	return doc.body;
+}
+
+// taking in embed code
+// adding on any powa fields
+// todo: return the embed code with the correct statuses
+const getEmbedHTMLWithPlayStatus = (embedMarkup) => {
+	if (embedMarkup) {
+		const embedHTMLWithPlayStatus = convertStringToNode(embedMarkup);
+
+		// innerhtml ensures body tag not rendered
+		return embedHTMLWithPlayStatus.innerHTML;
+	}
+	return "";
+};
+
+const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
+	// todo: implement client-side only check
 	return (
 		<div
 			className={containerClassNames}
@@ -12,7 +35,11 @@ const Video = ({ className, aspectRatio, viewportPercentage }) => {
 				"--aspect-ratio": aspectRatio,
 				"--viewport-percentage": viewportPercentage,
 			}}
-		/>
+		>
+			<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup)}>
+				<div dangerouslySetInnerHTML={{ __html: getEmbedHTMLWithPlayStatus(embedMarkup) }} />
+			</EmbedContainer>
+		</div>
 	);
 };
 

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -6,15 +6,15 @@ const COMPONENT_CLASS_NAME = "c-video";
 
 const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 	// only render or call powaboot on client-side
-	const isClientSide = typeof window !== "undefined";
+	const shouldRenderVideoContent = embedMarkup && typeof window !== "undefined";
 
 	useEffect(() => {
 		// will only ever run client-side as window object not available on server
 		// if powaboot available, call it
-		if (isClientSide && window.powaBoot) {
+		if (shouldRenderVideoContent && window.powaBoot) {
 			window.powaBoot();
 		}
-	}, [isClientSide]);
+	}, [shouldRenderVideoContent]);
 
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
@@ -26,7 +26,7 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 				"--height": viewportPercentage,
 			}}
 		>
-			{isClientSide ? (
+			{shouldRenderVideoContent ? (
 				<EmbedContainer markup={embedMarkup}>
 					<div
 						dangerouslySetInnerHTML={{

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -41,7 +41,7 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 			className={containerClassNames}
 			style={{
 				"--aspect-ratio": aspectRatio,
-				"--viewport-percentage": viewportPercentage,
+				"--height": viewportPercentage,
 			}}
 		>
 			<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup)}>

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -1,0 +1,30 @@
+import PropTypes from "prop-types";
+
+const COMPONENT_CLASS_NAME = "c-video";
+
+const Video = ({ className, viewportPercentage }) => {
+	const videoIsLoading = true;
+	const containerClassNames = [
+		COMPONENT_CLASS_NAME,
+		videoIsLoading && `${COMPONENT_CLASS_NAME}--not-loaded`,
+		className,
+	]
+		.filter((i) => i)
+		.join(" ");
+
+	return (
+		<div
+			className={containerClassNames}
+			style={{
+				"--viewport-percentage": viewportPercentage,
+			}}
+		/>
+	);
+};
+
+Video.propTypes = {
+	/** Class name(s) that get appended to default class name of the component */
+	className: PropTypes.string,
+};
+
+export default Video;

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -15,9 +15,23 @@ function convertStringToNode(string) {
 // taking in embed code
 // adding on any powa fields
 // todo: return the embed code with the correct statuses
-const getEmbedHTMLWithPlayStatus = (embedMarkup) => {
+const getEmbedHTMLWithPlayStatus = (embedMarkup, aspectRatio, powaFields = {}) => {
 	if (embedMarkup) {
 		const embedHTMLWithPlayStatus = convertStringToNode(embedMarkup);
+
+		// set the rest of powa fields, minus aspect ratio
+		// https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/
+		const powaFieldEntries = Object.entries(powaFields);
+
+		// set aspect ratio
+		// flip the resolution to match implementation in powa height / width
+		embedHTMLWithPlayStatus
+			.querySelector(".powa")
+			.setAttribute("data-aspect-ratio", 1 / aspectRatio);
+
+		powaFieldEntries.forEach(([key, value]) => {
+			embedHTMLWithPlayStatus.querySelector(".powa").setAttribute(`data-${key}`, value);
+		});
 
 		// innerhtml ensures body tag not rendered
 		return embedHTMLWithPlayStatus.innerHTML;
@@ -25,7 +39,7 @@ const getEmbedHTMLWithPlayStatus = (embedMarkup) => {
 	return "";
 };
 
-const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
+const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, powaFields }) => {
 	// only render or call powaboot on client-side
 	const isClientSide = typeof window !== "undefined";
 
@@ -48,8 +62,12 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
 			}}
 		>
 			{isClientSide ? (
-				<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup)}>
-					<div dangerouslySetInnerHTML={{ __html: getEmbedHTMLWithPlayStatus(embedMarkup) }} />
+				<EmbedContainer markup={getEmbedHTMLWithPlayStatus(embedMarkup, aspectRatio, powaFields)}>
+					<div
+						dangerouslySetInnerHTML={{
+							__html: getEmbedHTMLWithPlayStatus(embedMarkup, aspectRatio, powaFields),
+						}}
+					/>
 				</EmbedContainer>
 			) : null}
 		</div>

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -2,8 +2,9 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-video";
 
-const Video = ({ className, viewportPercentage }) => {
+const Video = ({ className, aspectRatio, viewportPercentage }) => {
 	const videoIsLoading = true;
+
 	const containerClassNames = [
 		COMPONENT_CLASS_NAME,
 		videoIsLoading && `${COMPONENT_CLASS_NAME}--not-loaded`,
@@ -16,6 +17,7 @@ const Video = ({ className, viewportPercentage }) => {
 		<div
 			className={containerClassNames}
 			style={{
+				"--aspect-ratio": aspectRatio,
 				"--viewport-percentage": viewportPercentage,
 			}}
 		/>
@@ -25,6 +27,10 @@ const Video = ({ className, viewportPercentage }) => {
 Video.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
+	/** The aspect ratio of the video */
+	aspectRatio: PropTypes.number,
+	/* The vertical percentage of the viewport takes up */
+	viewportPercentage: PropTypes.number,
 };
 
 export default Video;

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -3,15 +3,7 @@ import PropTypes from "prop-types";
 const COMPONENT_CLASS_NAME = "c-video";
 
 const Video = ({ className, aspectRatio, viewportPercentage }) => {
-	const videoIsLoading = true;
-
-	const containerClassNames = [
-		COMPONENT_CLASS_NAME,
-		videoIsLoading && `${COMPONENT_CLASS_NAME}--not-loaded`,
-		className,
-	]
-		.filter((i) => i)
-		.join(" ");
+	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
 	return (
 		<div

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import PropTypes from "prop-types";
 import EmbedContainer from "react-oembed-container";
 
@@ -25,9 +26,16 @@ const getEmbedHTMLWithPlayStatus = (embedMarkup) => {
 };
 
 const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup }) => {
+	useEffect(() => {
+		// will only ever run client-side as window object not available on server
+		// if powaboot available, call it
+		if (window.powaBoot) {
+			window.powaBoot();
+		}
+	}, []);
+
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
-	// todo: implement client-side only check
 	return (
 		<div
 			className={containerClassNames}

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -28,7 +28,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video Half Vertical Viewport Loading">
 		<Video
 			viewportPercentage={50}
-			aspectRatio={1 / 0.562}
+			aspectRatio={4 / 3}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -42,7 +42,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video Full Vertical Viewport Loading">
 		<Video
 			viewportPercentage={100}
-			aspectRatio={1 / 0.562}
+			aspectRatio={4 / 3}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -56,7 +56,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video One Third Vertical Viewport Loading">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={1 / 0.562}
+			aspectRatio={4 / 3}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -64,23 +64,58 @@ const Feature = () => <Video>Component Children</Video>;
 	</Story>
 </Canvas>
 
-** Two videos **
+** Two videos, different aspect ratios **
 
 <Canvas>
-	<Story name="Two videos">
+	<Story name="Two videos, different aspect ratios">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={1 / 0.562}
+			aspectRatio={4 / 3}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
 		/>
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={1 / 0.562}
+			aspectRatio={16 / 9}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
+		/>
+	</Story>
+</Canvas>
+
+** Set powa fields playthrough **
+
+<Canvas>
+	<Story name="Set powa fields playthrough">
+		<Video
+			viewportPercentage={33.33}
+			aspectRatio={4 / 3}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+			powaFields={{
+				playthrough: true,
+			}}
+		/>
+	</Story>
+</Canvas>
+
+** Set powa fields muted autoplay **
+
+<Canvas>
+	<Story name="Set powa fields muted autoplay">
+		<Video
+			viewportPercentage={33.33}
+			aspectRatio={4 / 3}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+			powaFields={{
+				autoplay: true,
+				muted: true,
+			}}
 		/>
 	</Story>
 </Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -63,3 +63,24 @@ const Feature = () => <Video>Component Children</Video>;
 		/>
 	</Story>
 </Canvas>
+
+** Two videos **
+
+<Canvas>
+	<Story name="Two videos">
+		<Video
+			viewportPercentage={33.33}
+			aspectRatio={1 / 0.562}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
+		<Video
+			viewportPercentage={33.33}
+			aspectRatio={1 / 0.562}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
+	</Story>
+</Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -26,7 +26,13 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video Half Vertical Viewport Loading">
-		<Video viewportPercentage={50} aspectRatio={1} />
+		<Video
+			viewportPercentage={50}
+			aspectRatio={1 / 0.562}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
 	</Story>
 </Canvas>
 
@@ -34,7 +40,13 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video Full Vertical Viewport Loading">
-		<Video viewportPercentage={100} aspectRatio={1} />
+		<Video
+			viewportPercentage={100}
+			aspectRatio={1 / 0.562}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
 	</Story>
 </Canvas>
 
@@ -42,6 +54,12 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video One Third Vertical Viewport Loading">
-		<Video viewportPercentage={33.33} aspectRatio={1} />
+		<Video
+			viewportPercentage={33.33}
+			aspectRatio={1 / 0.562}
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
 	</Story>
 </Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -6,7 +6,11 @@ import Video from ".";
 
 # Video
 
---- Add a description of the component here ---
+The `Video` component is a container used to initiate and display a Powa video player. The container is designed to save space for the video while the video is loading. It takes in an `embedMarkup` string that is rendered on the client-side. For more information on customizing that string, see the `Utilities/Format Powa Video Embed` story.
+
+To maximize Core Web Vitals scores, the `aspect-ratio` property can be set to match the `embedMarkup`'s expected data. Please see [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) and [Google's advice](https://web.dev/aspect-ratio/#maintaining-aspect-ratio-with-aspect-ratio) on this pattern.
+
+The `viewportPercentage` property can be used to set the percentage of the vertical viewport that the video should occupy. The default is `65`. This is designed so that the video's aspect ratio and video container maintain the desired aspect-ratio. For a mobile user, this can be helpful to ensure a vertical video does not take up the entire viewport.
 
 ## Usage
 
@@ -28,7 +32,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video Half Vertical Viewport Loading">
 		<Video
 			viewportPercentage={50}
-			aspectRatio={4 / 3}
+			aspectRatio={1 / 0.562}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -42,7 +46,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video Full Vertical Viewport Loading">
 		<Video
 			viewportPercentage={100}
-			aspectRatio={4 / 3}
+			aspectRatio={1 / 0.562}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -56,7 +60,7 @@ const Feature = () => <Video>Component Children</Video>;
 	<Story name="Video One Third Vertical Viewport Loading">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={4 / 3}
+			aspectRatio={1 / 0.562}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -72,50 +76,15 @@ const Feature = () => <Video>Component Children</Video>;
 			viewportPercentage={33.33}
 			aspectRatio={4 / 3}
 			embedMarkup={
-				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.75" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
 		/>
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={16 / 9}
+			aspectRatio={1 / 0.562}
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
-		/>
-	</Story>
-</Canvas>
-
-** Set powa fields playthrough **
-
-<Canvas>
-	<Story name="Set powa fields playthrough">
-		<Video
-			viewportPercentage={33.33}
-			aspectRatio={4 / 3}
-			embedMarkup={
-				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
-			}
-			powaFields={{
-				playthrough: true,
-			}}
-		/>
-	</Story>
-</Canvas>
-
-** Set powa fields muted autoplay **
-
-<Canvas>
-	<Story name="Set powa fields muted autoplay">
-		<Video
-			viewportPercentage={33.33}
-			aspectRatio={4 / 3}
-			embedMarkup={
-				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
-			}
-			powaFields={{
-				autoplay: true,
-				muted: true,
-			}}
 		/>
 	</Story>
 </Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -26,7 +26,7 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video Half Vertical Viewport Loading">
-		<Video viewportPercentage={50} />
+		<Video viewportPercentage={50} aspectRatio={1} />
 	</Story>
 </Canvas>
 
@@ -34,7 +34,7 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video Full Vertical Viewport Loading">
-		<Video viewportPercentage={100} />
+		<Video viewportPercentage={100} aspectRatio={1} />
 	</Story>
 </Canvas>
 
@@ -42,6 +42,6 @@ const Feature = () => <Video>Component Children</Video>;
 
 <Canvas>
 	<Story name="Video One Third Vertical Viewport Loading">
-		<Video viewportPercentage={33.33} />
+		<Video viewportPercentage={33.33} aspectRatio={1} />
 	</Story>
 </Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -1,0 +1,47 @@
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+
+import Video from ".";
+
+<Meta title="Components/Video" component={Video} />
+
+# Video
+
+--- Add a description of the component here ---
+
+## Usage
+
+```jsx
+import { Video } from "@wpmedia/arc-themes-components";
+
+const Feature = () => <Video>Component Children</Video>;
+```
+
+## Properties
+
+<ArgsTable of={Video} />
+
+## Stories
+
+** Video Half Vertical Viewport Loading **
+
+<Canvas>
+	<Story name="Video Half Vertical Viewport Loading">
+		<Video viewportPercentage={50} />
+	</Story>
+</Canvas>
+
+** Video Full Vertical Viewport Loading **
+
+<Canvas>
+	<Story name="Video Full Vertical Viewport Loading">
+		<Video viewportPercentage={100} />
+	</Story>
+</Canvas>
+
+** Video One Third Vertical Viewport Loading **
+
+<Canvas>
+	<Story name="Video One Third Vertical Viewport Loading">
+		<Video viewportPercentage={33.33} />
+	</Story>
+</Canvas>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -17,7 +17,12 @@ The `viewportPercentage` property can be used to set the percentage of the verti
 ```jsx
 import { Video } from "@wpmedia/arc-themes-components";
 
-const Feature = () => <Video>Component Children</Video>;
+const Feature = () => {
+	const embedMarkup =
+		'<div class="powa" id="powa-ezzy" data-org="corecomponents" data-env="prod" data-uuid="ezzy" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
+
+	return <Video embedMarkup={embedMarkup} aspectRatio={16 / 9} viewportPercentage={50} />;
+};
 ```
 
 ## Properties

--- a/src/components/video/index.test.jsx
+++ b/src/components/video/index.test.jsx
@@ -5,12 +5,31 @@ import Video from ".";
 const COMPONENT_CLASS_NAME = "c-video";
 
 describe("Video", () => {
-	it("should render", () => {
+	it("should render only container", () => {
 		const { container } = render(<Video />);
 		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).not.toBeNull();
+		expect(container.querySelector(".powa")).toBeNull();
 	});
-	it("should render with additional class", () => {
+	it("should render only container with additional class", () => {
 		const { container } = render(<Video className="additionalClass" />);
 		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveClass("additionalClass");
+		expect(container.querySelector(".powa")).toBeNull();
+	});
+	it("should render container with aspect ratio", () => {
+		const { container } = render(<Video aspectRatio={16 / 9} />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle(
+			"--aspect-ratio: 1.7777777777777777"
+		);
+	});
+	it("should render container with vertical viewport percentage", () => {
+		const { container } = render(<Video viewportPercentage={50} />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--height: 50");
+	});
+	it("should initiate video and render markup if not empty", () => {
+		// mock window powa boot function to mimick powa
+		window.powaBoot = jest.fn();
+		const { container } = render(<Video embedMarkup="<div class='powa' />" />);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(".powa")).not.toBeNull();
 	});
 });

--- a/src/components/video/index.test.jsx
+++ b/src/components/video/index.test.jsx
@@ -1,0 +1,16 @@
+import { render } from "@testing-library/react";
+
+import Video from ".";
+
+const COMPONENT_CLASS_NAME = "c-video";
+
+describe("Video", () => {
+	it("should render", () => {
+		const { container } = render(<Video />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).not.toBeNull();
+	});
+	it("should render with additional class", () => {
+		const { container } = render(<Video className="additionalClass" />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveClass("additionalClass");
+	});
+});

--- a/src/utils/format-powa-video-embed/formatPowaVideoEmbed.test.js
+++ b/src/utils/format-powa-video-embed/formatPowaVideoEmbed.test.js
@@ -1,0 +1,19 @@
+import formatPowaVideoEmbed from ".";
+
+it("returns an empty string if empty embed markup", () => {
+	expect(formatPowaVideoEmbed()).toMatchInlineSnapshot(`""`);
+});
+
+it("returns a non-empty string if there are no powa fields", () => {
+	expect(formatPowaVideoEmbed('<div class="powa"></div>')).toMatchInlineSnapshot(
+		`"<div class=\\"powa\\"></div>"`
+	);
+});
+
+it("returns a powa embed code with fields attached with data-", () => {
+	expect(
+		formatPowaVideoEmbed('<div class="powa" ></div>', {
+			powaVideoId: "12345",
+		})
+	).toMatchInlineSnapshot(`"<div class=\\"powa\\" data-powavideoid=\\"12345\\"></div>"`);
+});

--- a/src/utils/format-powa-video-embed/index.js
+++ b/src/utils/format-powa-video-embed/index.js
@@ -1,0 +1,22 @@
+const formatPowaVideoEmbed = (embedMarkup, powaFields = {}) => {
+	if (embedMarkup) {
+		// get markup as node to set properties
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(embedMarkup, "text/html");
+		const embedHTMLWithPlayStatus = doc.body;
+
+		const powaFieldEntries = Object.entries(powaFields);
+
+		// set the rest of powa fields
+		// https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/
+		powaFieldEntries.forEach(([key, value]) => {
+			embedHTMLWithPlayStatus.querySelector(".powa").setAttribute(`data-${key}`, value);
+		});
+
+		// innerhtml ensures body tag not rendered
+		return embedHTMLWithPlayStatus.innerHTML;
+	}
+	return "";
+};
+
+export default formatPowaVideoEmbed;

--- a/src/utils/format-powa-video-embed/index.stories.mdx
+++ b/src/utils/format-powa-video-embed/index.stories.mdx
@@ -1,0 +1,67 @@
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
+
+import formatPowaVideoEmbed from ".";
+
+<Meta title="Utilities/Format Powa Video Embed" component={formatPowaVideoEmbed} />
+
+# Format Powa Video Embed
+
+The `formatPowaVideoEmbed()` function takes in a string containing a Powa Video embed code and returns a markup containing the embed code with Powa fields set. To see all available Powa fields, see: https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/
+
+The properties are set on the node using the `data-` attribute.
+
+This follows the [ANS schema](https://github.com/washingtonpost/ans-schema) for Video.
+
+## Usage
+
+```jsx
+import formatPowaVideoEmbed from "./formatPowaVideoEmbed";
+import Video from "./Video";
+
+const CustomVideoFeature = () => {
+	const embedMarkup =
+		'<div class="powa" id="powa-e9zzz" data-org="your-org" data-env="prod" data-uuid="e9zzz" data-api="prod"><script src="//fff.cloudfront.net/prod/powaBoot.js?org=your-org"></script></div>';
+
+	const powaFields = {
+		muted: true,
+		autoplay: true,
+	};
+
+	const configuredEmbed = formatPowaVideoEmbed(embedMarkup, powaFields);
+
+	return <Video embedMarkup={configuredEmbed} />;
+};
+```
+
+## Properties
+
+| Name            | Description                                                                                                                                                                                                       | Default |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| **embedMarkup** | Takes in a string like `<div class="powa" id="powa-e9zzz" data-org="your-org" data-env="prod" data-uuid="e9zzz" data-api="prod"><script src="//fff.cloudfront.net/prod/powaBoot.js?org=your-org"></script></div>` | -       |
+| **powaFields**  | Takes in an object with Powa fields to set on the node. See: https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/                                            | {}      |
+
+## Stories
+
+** With no fields set **
+
+<Canvas>
+	<Story name="With no fields set">
+		{formatPowaVideoEmbed(
+			'<div class="powa" id="powa-e9zzz"><script src="//fff.cloudfront.net/prod/powaBoot.js?org=your-org"></script></div>'
+		)}
+	</Story>
+</Canvas>
+
+** With autoplay and muted fields set **
+
+<Canvas>
+	<Story name="With autoplay and muted fields set">
+		{formatPowaVideoEmbed(
+			'<div class="powa" id="powa-e9zzz"><script src="//fff.cloudfront.net/prod/powaBoot.js?org=your-org"></script></div>',
+			{
+				muted: true,
+				autoplay: true,
+			}
+		)}
+	</Story>
+</Canvas>


### PR DESCRIPTION
## Ticket

- [TMEDIA-709](https://arcpublishing.atlassian.net/browse/TMEDIA-709)

## Description

Migrate video player from engine theme sdk. Used utilities pattern so that clients can create their own video player implementation if necessary. 

## Acceptance Criteria

Provide a <Video> component

Migrate the video player component from the SDK without caption object

Custom fields: 

Viewport percentage

Aspect ratio

Shrink to fit

Autoplay

Playthrough

Use all options available to Powa (docs: https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-video-center-player/ [Sign in | Arc Publishing](https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/) )

Have Scss file that adds the hooks to the Sass library

Have test coverage

Have storybook documentation

## Test Steps

1. Checkout branch - `git checkout TMEDIA-709-video-player`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Video and format video markup storybook documentation

## Notes

# Todo

- [x] FIgure out how aspect ratio interacts with vertical viewport width so that the div with background-color (currently hard-coded, debateable to be included) is a sufficient placeholder to minimize cls. Ideally `aspect-ratio` and `height` could be used alone with powa player -> I think `aspect-ratio` is what we want to use. `height` will need to be determined by viewport height
- [x] Set all the props available on powa, perhaps with a powa settings object, that will spread onto the powa library essentially  -> spreading the keys and values. need to link to powa docs on this and test. 
- [x] Detect video loading to remove the class "--not-loaded" upon powa initialization. Remove hard-coded isLoading state. -> removing this. as I shouldn't need to detect loading state if aspect-ratio is known
- [x] Install react-embed so that we can set the powa player code 

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
