### PR TITLE
Update Reset for Media Items, Bold and Italic 

### DIFF
--- a/src/scss/root/_reset.scss
+++ b/src/scss/root/_reset.scss
@@ -59,7 +59,7 @@ picture,
 video,
 canvas,
 svg {
-	display: block;
+	display: inline-block;
 	min-width: 0;
 	max-width: 100%;
 	vertical-align: middle;
@@ -76,4 +76,11 @@ button,
 textarea,
 select {
 	font: inherit;
+}
+strong {
+	font-weight: bold;
+}
+
+em {
+	font-style: italic;
 }


### PR DESCRIPTION
## Jira Ticket

- [TMEDIA-771](https://arcpublishing.atlassian.net/browse/TMEDIA-771)

## Description

While update the blocks storybook to use the new Sass library it showed some issues with our current reset that would cause a lot of visual regressions by switching over. These three updates are the main causes of the regressions

Use inline-block for img/media element, set bold and italic defaults

Blocks PR - https://github.com/WPMedia/arc-themes-blocks/pull/1301
Blocks Chromatic run - https://www.chromatic.com/build?appId=5f91e4721ccaba0022a10782&number=1843


## Test Steps

1. Checkout branch - `git checkout reset-updates`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
