### PR TITLE
Add assistiveHidden prop to button

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -12,6 +12,7 @@ const COMPONENT_CLASS_NAME = "c-button";
 const Button = forwardRef((props, ref) => {
 	const {
 		accessibilityLabel,
+		assistiveHidden,
 		children,
 		className,
 		disabled,
@@ -29,6 +30,8 @@ const Button = forwardRef((props, ref) => {
 		...rest,
 		ref,
 		"aria-label": accessibilityLabel,
+		"aria-hidden": assistiveHidden ? "true" : undefined,
+		tabIndex: assistiveHidden ? "-1" : undefined,
 		className: [
 			COMPONENT_CLASS_NAME,
 			href && `${COMPONENT_CLASS_NAME}--link`,
@@ -73,6 +76,8 @@ Button.defaultProps = {
 Button.propTypes = {
 	/** Provide an accessible name to the button - use only when the button itself does not have meaningful text content */
 	accessibilityLabel: PropTypes.string,
+	/** Remove the button from the accessibility tree with aria-hidden, tabindex=-1 */
+	assistiveHidden: PropTypes.bool,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */

--- a/src/components/button/index.test.jsx
+++ b/src/components/button/index.test.jsx
@@ -46,4 +46,13 @@ describe("Button", () => {
 		const element = screen.getByRole("link");
 		expect(element).toHaveClass(ORIGINAL_CLASSES);
 	});
+
+	it("should respond to assistiveHidden and show tab index -1 and aria-hidden", () => {
+		render(<Button assistiveHidden>Button Text</Button>);
+
+		const element = screen.getByRole("button", { hidden: true });
+
+		expect(element).toHaveAttribute("aria-hidden", "true");
+		expect(element).toHaveAttribute("tabIndex", "-1");
+	});
 });


### PR DESCRIPTION
## Description

Based on the work for the Quilted Image block there's a need to have the Button removed from assistive technologies, and tab order as it is within a link. To be consistent with the link component this adds the same prop in the link component `assistiveHidden` to the button component

## Test Steps

Tests, actions, and chromatic should be enough to verify the changes

For manual testing -

1. Checkout branch - `git checkout button-assistive-hidden-prop`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
