### PR TITLE
TMEDIA-778 - Allow components to not need a default value set within components map

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -19,7 +19,8 @@
 					"css-appearance",
 					"intrinsic-width",
 					"viewport-units",
-					"css3-cursor"
+					"css3-cursor",
+					"css-initial-value"
 				],
 				"ignorePartialSupport": true,
 				"severity": "warning"
@@ -38,7 +39,12 @@
 				"ignoreProperties": ["box-orient", "appearance"]
 			}
 		],
-		"value-no-vendor-prefix": [true, { "ignoreValues": ["box"] }],
+		"value-no-vendor-prefix": [
+			true,
+			{
+				"ignoreValues": ["box"]
+			}
+		],
 		"order/order": null,
 		"selector-class-pattern": [
 			"c-[a-z]+",

--- a/src/scss/index.test.scss
+++ b/src/scss/index.test.scss
@@ -1,5 +1,71 @@
 @use "true" as *;
 
+$tokens: (
+	default: (
+		alias: (),
+		components: (
+			"block1": (
+				"font-size": var(--font-size-tiny),
+			),
+			"component1": (
+				"font-size": var(--font-size-small),
+			),
+			"with-state": (
+				"font-size": var(--font-size-small),
+			),
+			"with-state-hover": (
+				"font-size": var(--font-size-tiny),
+			),
+			"with-state-active": (
+				"font-size": var(--font-size-tiny),
+			),
+		),
+		blocks: (
+			"block1": (
+				"font-size": var(--font-size-small),
+				components: (
+					"component1": (
+						"font-size": var(--font-size-small),
+					),
+				),
+			),
+			"block2": (
+				components: (
+					"component2": (
+						"font-size": var(--font-size-large),
+						"font-weight": 900,
+					),
+				),
+			),
+		),
+	),
+	tablet: (
+		alias: (),
+		components: (),
+		blocks: (
+			"block1": (
+				components: (
+					"component1": (
+						"font-size": var(--font-size-large),
+					),
+				),
+			),
+			"block2": (
+				components: (
+					"component2": (
+						"color": red,
+					),
+				),
+			),
+		),
+	),
+	desktop: (
+		alias: (),
+		components: (),
+		blocks: (),
+	),
+);
+
 @use "root" with (
 	$alias: (),
 	$breakpoints: (
@@ -8,56 +74,7 @@
 		desktop: "min-width: 48rem",
 	),
 	$global: (),
-	$tokens: (
-		default: (
-			alias: (),
-			components: (
-				"block1": (
-					"font-size": var(--font-size-tiny),
-				),
-				"component1": (
-					"font-size": var(--font-size-small),
-				),
-				"with-state": (
-					"font-size": var(--font-size-small),
-				),
-				"with-state-hover": (
-					"font-size": var(--font-size-tiny),
-				),
-				"with-state-active": (
-					"font-size": var(--font-size-tiny),
-				),
-			),
-			blocks: (
-				"block1": (
-					"font-size": var(--font-size-small),
-					components: (
-						"component1": (
-							"font-size": var(--font-size-small),
-						),
-					),
-				),
-			),
-		),
-		tablet: (
-			alias: (),
-			components: (),
-			blocks: (
-				"block1": (
-					components: (
-						"component1": (
-							"font-size": var(--font-size-large),
-						),
-					),
-				),
-			),
-		),
-		desktop: (
-			alias: (),
-			components: (),
-			blocks: (),
-		),
-	)
+	$tokens: $tokens
 );
 
 @include describe("root-tokens") {
@@ -214,10 +231,11 @@
 	@include it("returns appropriate value for definition that does exist") {
 		@include assert {
 			@include output {
-				@include root.component-properties("component1");
+				@include root.component-properties("component2");
 			}
 			@include expect {
 				font-size: var(--c-component1-font-size);
+				font-weight: var(--c-component1-font-weight);
 			}
 		}
 	}
@@ -293,5 +311,46 @@
 @include describe("block-var") {
 	@include it("returns appropriate value for definition that does exist") {
 		@include assert-equal(root.block-var("block1", "font-size"), "var(--b-block1-font-size)");
+	}
+}
+
+@include describe("get-all-component-definitions") {
+	@include it("returns appropriate value for definition that does exist") {
+		@include assert-equal(root.get-all-component-definitions(), ());
+	}
+
+	@include it("returns appropriate value for definition that does exist") {
+		@include assert-equal(
+			root.get-all-component-definitions(
+				$tokens,
+				(
+					default: "min-width: 0",
+					tablet: "min-width: 20rem",
+					desktop: "min-width: 48rem",
+				)
+			),
+			(
+				"block1": (
+					"font-size": var(--font-size-tiny),
+				),
+				"component1": (
+					"font-size": var(--font-size-small),
+				),
+				"with-state": (
+					"font-size": var(--font-size-small),
+				),
+				"with-state-hover": (
+					"font-size": var(--font-size-tiny),
+				),
+				"with-state-active": (
+					"font-size": var(--font-size-tiny),
+				),
+				"component2": (
+					"color": initial,
+					"font-size": initial,
+					"font-weight": initial,
+				),
+			)
+		);
 	}
 }

--- a/src/scss/index.test.scss
+++ b/src/scss/index.test.scss
@@ -234,8 +234,9 @@ $tokens: (
 				@include root.component-properties("component2");
 			}
 			@include expect {
-				font-size: var(--c-component1-font-size);
-				font-weight: var(--c-component1-font-weight);
+				font-size: var(--c-component2-font-size);
+				font-weight: var(--c-component2-font-weight);
+				color: var(--c-component2-color);
 			}
 		}
 	}

--- a/src/scss/root/_index.scss
+++ b/src/scss/root/_index.scss
@@ -105,7 +105,6 @@ $tokens: () !default;
 	@if list.length($tokens) != 0 {
 		:root {
 			// Alias Tokens
-
 			@if map.has-key($tokens, "alias") == true {
 				@each $name, $value in map.get($tokens, "alias") {
 					--#{$name}: #{maintain-quotes($value)};
@@ -135,6 +134,40 @@ $tokens: () !default;
 @function maintain-quotes($item) {
 	@return #{meta.inspect($item)};
 }
+
+@function get-all-component-definitions($allTokens: (), $breakpoints: ()) {
+	$componentMaps: ();
+
+	@if type-of($allTokens) != map {
+		@return $componentMaps;
+	}
+
+	@if map.has-key($allTokens, "default", "components") {
+		@each $name, $value in map.get($allTokens, "default", "components") {
+			$componentMaps: map.set($componentMaps, $name, $value);
+		}
+	}
+
+	@each $breakpoint, $breakpointValue in $breakpoints {
+		@each $blockName, $blockValue in map.get($allTokens, $breakpoint, "blocks") {
+			@if type-of($blockValue) == map {
+				@if list.length(map.get($blockValue, "components")) >= 0 {
+					@each $name, $value in map.get($blockValue, "components") {
+						@each $cName, $cValue in $value {
+							@if map.get($componentMaps, $name, $cName) == null {
+								$componentMaps: map.set($componentMaps, $name, $cName, "initial");
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@return $componentMaps;
+}
+
+$componentMaps: get-all-component-definitions($tokens);
 
 //
 // Start of output of CSS Variables

--- a/src/scss/root/_index.scss
+++ b/src/scss/root/_index.scss
@@ -38,26 +38,27 @@ $tokens: () !default;
 }
 
 @function get-all-component-definitions($allTokens: (), $breakpoints: ()) {
-	$componentMaps: ();
+	$component-map: ();
 
 	@if type-of($allTokens) != map {
-		@return $componentMaps;
+		@return $component-map;
 	}
 
 	@if map.has-key($allTokens, "default", "components") {
 		@each $name, $value in map.get($allTokens, "default", "components") {
-			$componentMaps: map.set($componentMaps, $name, $value);
+			$component-map: map.set($component-map, $name, $value);
 		}
 	}
 
+	/* stylelint-disable max-nesting-depth */
 	@each $breakpoint, $breakpointValue in $breakpoints {
 		@each $blockName, $blockValue in map.get($allTokens, $breakpoint, "blocks") {
 			@if type-of($blockValue) == map {
 				@if list.length(map.get($blockValue, "components")) >= 0 {
 					@each $name, $value in map.get($blockValue, "components") {
 						@each $cName, $cValue in $value {
-							@if map.get($componentMaps, $name, $cName) == null {
-								$componentMaps: map.set($componentMaps, $name, $cName, "initial");
+							@if map.get($component-map, $name, $cName) == null {
+								$component-map: map.set($component-map, $name, $cName, "initial");
 							}
 						}
 					}
@@ -66,11 +67,11 @@ $tokens: () !default;
 		}
 	}
 
-	@return $componentMaps;
+	@return $component-map;
 }
 
 // Map of all components unique properties
-$componentMaps: get-all-component-definitions($tokens, $breakpoints);
+$component-map: get-all-component-definitions($tokens, $breakpoints);
 
 //
 // Mixins
@@ -102,8 +103,8 @@ $componentMaps: get-all-component-definitions($tokens, $breakpoints);
 }
 
 @mixin component-properties($component) {
-	@if map.has-key($componentMaps, $component) {
-		@each $name, $value in map.get($componentMaps, $component) {
+	@if map.has-key($component-map, $component) {
+		@each $name, $value in map.get($component-map, $component) {
 			#{$name}: component-var($component, $name);
 		}
 	}

--- a/src/scss/root/_index.scss
+++ b/src/scss/root/_index.scss
@@ -23,6 +23,56 @@ $tokens: () !default;
 }
 
 //
+// Functions
+//
+@function component-var($component, $item) {
+	@return var(--c-#{$component}-#{$item});
+}
+
+@function block-var($block, $item) {
+	@return var(--b-#{$block}-#{$item});
+}
+
+@function maintain-quotes($item) {
+	@return #{meta.inspect($item)};
+}
+
+@function get-all-component-definitions($allTokens: (), $breakpoints: ()) {
+	$componentMaps: ();
+
+	@if type-of($allTokens) != map {
+		@return $componentMaps;
+	}
+
+	@if map.has-key($allTokens, "default", "components") {
+		@each $name, $value in map.get($allTokens, "default", "components") {
+			$componentMaps: map.set($componentMaps, $name, $value);
+		}
+	}
+
+	@each $breakpoint, $breakpointValue in $breakpoints {
+		@each $blockName, $blockValue in map.get($allTokens, $breakpoint, "blocks") {
+			@if type-of($blockValue) == map {
+				@if list.length(map.get($blockValue, "components")) >= 0 {
+					@each $name, $value in map.get($blockValue, "components") {
+						@each $cName, $cValue in $value {
+							@if map.get($componentMaps, $name, $cName) == null {
+								$componentMaps: map.set($componentMaps, $name, $cName, "initial");
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	@return $componentMaps;
+}
+
+// Map of all components unique properties
+$componentMaps: get-all-component-definitions($tokens, $breakpoints);
+
+//
 // Mixins
 //
 @mixin block-components($blockName) {
@@ -52,8 +102,8 @@ $tokens: () !default;
 }
 
 @mixin component-properties($component) {
-	@if map.has-key($tokens, "default", "components", $component) {
-		@each $name, $value in map.get($tokens, "default", "components", $component) {
+	@if map.has-key($componentMaps, $component) {
+		@each $name, $value in map.get($componentMaps, $component) {
 			#{$name}: component-var($component, $name);
 		}
 	}
@@ -119,55 +169,6 @@ $tokens: () !default;
 		}
 	}
 }
-
-//
-// Functions
-//
-@function component-var($component, $item) {
-	@return var(--c-#{$component}-#{$item});
-}
-
-@function block-var($block, $item) {
-	@return var(--b-#{$block}-#{$item});
-}
-
-@function maintain-quotes($item) {
-	@return #{meta.inspect($item)};
-}
-
-@function get-all-component-definitions($allTokens: (), $breakpoints: ()) {
-	$componentMaps: ();
-
-	@if type-of($allTokens) != map {
-		@return $componentMaps;
-	}
-
-	@if map.has-key($allTokens, "default", "components") {
-		@each $name, $value in map.get($allTokens, "default", "components") {
-			$componentMaps: map.set($componentMaps, $name, $value);
-		}
-	}
-
-	@each $breakpoint, $breakpointValue in $breakpoints {
-		@each $blockName, $blockValue in map.get($allTokens, $breakpoint, "blocks") {
-			@if type-of($blockValue) == map {
-				@if list.length(map.get($blockValue, "components")) >= 0 {
-					@each $name, $value in map.get($blockValue, "components") {
-						@each $cName, $cValue in $value {
-							@if map.get($componentMaps, $name, $cName) == null {
-								$componentMaps: map.set($componentMaps, $name, $cName, "initial");
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	@return $componentMaps;
-}
-
-$componentMaps: get-all-component-definitions($tokens);
 
 //
 // Start of output of CSS Variables


### PR DESCRIPTION
## Ticket

- [TMEDIA-778](https://arcpublishing.atlassian.net/browse/TMEDIA-778)

## Description

Currently the Sass library requires components to have initial vales set within the components sass map before a component inside a block can change or set that value. This update goes through all the maps and finds all the unique properties for each component and defaults the values for you, meaning you can set just the color of the paragraph component in one block and not have to set the color property on the paragraph component map

Before you had to do this
```
$tokens: (
	default: (
		components: (
			paragraph: (
				color: initial,
			),
		),
		blocks: (
			hero: (
				components: (
					paragraph: (
						color: red,
					),
				),
			),
		),
	),
)
```

Now you can do this

```
$tokens: (
	default: (
		blocks: (
			hero: (
				components: (
					paragraph: (
						color: red,
					),
				),
			),
		),
	),
)
```


## Test Steps

1. Checkout branch - `git checkout TMEDIA-778`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
