### PR TITLE
TMEDIA-834 full screen carousel (off of tmedia 689)

### DIFF
--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -38,6 +38,11 @@
 		@include scss.component-properties("carousel-actions");
 	}
 
+	&__top-actions {
+		z-index: 1;
+		@include scss.component-properties("carousel-top-actions");
+	}
+
 	&__button {
 		@include scss.component-properties("carousel-button");
 

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -50,9 +50,13 @@
 		&--previous {
 			@include scss.component-properties("carousel-button-previous");
 		}
-	}
 
-	&__full-screen-toggle {
-		@include scss.component-properties("carousel-full-screen-toggle");
+		&--enter-full-screen {
+			@include scss.component-properties("carousel-button-enter-full-screen");
+		}
+
+		&--exit-full-screen {
+			@include scss.component-properties("carousel-button-exit-full-screen");
+		}
 	}
 }

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -39,7 +39,12 @@
 	}
 
 	&__top-actions {
+		display: flex;
+		justify-content: space-between;
+		place-self: start;
+		width: 100%;
 		z-index: 1;
+
 		@include scss.component-properties("carousel-top-actions");
 	}
 

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -4,7 +4,7 @@
 	--slide-width: var(--carousel-slide-width, 25%);
 
 	display: grid;
-	grid-template-areas: "carousel";
+	grid-template-areas: "top-actions" "carousel";
 	overflow: hidden;
 	word-break: break-word;
 
@@ -43,11 +43,7 @@
 	}
 
 	&__top-actions {
-		display: flex;
-		justify-content: space-between;
-		place-self: start;
-		width: 100%;
-		z-index: 1;
+		grid-area: top-actions;
 
 		@include scss.component-properties("carousel-top-actions");
 	}

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -51,4 +51,8 @@
 			@include scss.component-properties("carousel-button-previous");
 		}
 	}
+
+	&__full-screen-toggle {
+		@include scss.component-properties("carousel-full-screen-toggle");
+	}
 }

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -194,6 +194,7 @@ const Carousel = ({
 	);
 };
 
+Carousel.Button = Button;
 Carousel.Item = Item;
 
 Carousel.defaultProps = {

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -29,6 +29,28 @@ const DefaultPreviousButton = ({ id, onClick }) => (
 	</Button>
 );
 
+const DefaultMinimizeScreenButton = ({ id, onClick }) => (
+	<Button
+		id={id}
+		onClick={onClick}
+		label="Exit full screen mode displaying the carousel"
+		className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+	>
+		Minimize Screen
+	</Button>
+);
+
+const DefaultShowScreenButton = ({ id, onClick }) => (
+	<Button
+		id={id}
+		onClick={onClick}
+		label="Enter full screen mode displaying the carousel"
+		className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+	>
+		Full Screen
+	</Button>
+);
+
 const Carousel = ({
 	children,
 	className,
@@ -145,13 +167,7 @@ const Carousel = ({
 			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenShowButton.props?.className}`,
 		})
 	) : (
-		<button
-			onClick={toggleFullScreen}
-			type="button"
-			className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
-		>
-			Full Screen
-		</button>
+		<DefaultShowScreenButton id={id} onClick={toggleFullScreen} />
 	);
 
 	const resolvedFullScreenMinimizeButton = fullScreenMinimizeButton ? (
@@ -160,13 +176,7 @@ const Carousel = ({
 			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenMinimizeButton.props?.className}`,
 		})
 	) : (
-		<button
-			onClick={toggleFullScreen}
-			type="button"
-			className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
-		>
-			Minimize Screen
-		</button>
+		<DefaultMinimizeScreenButton id={id} onClick={toggleFullScreen} />
 	);
 
 	const fullScreenEnabledAllowed =

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -39,7 +39,7 @@ const Carousel = ({
 	slidesToShow,
 	fullScreenShowButton,
 	fullScreenMinimizeButton,
-	enableFullScreenToggleButton,
+	enableFullScreen,
 	...rest
 }) => {
 	const [slide, setSlide] = useState(slidesToShow);
@@ -170,8 +170,7 @@ const Carousel = ({
 	);
 
 	const fullScreenEnabledAllowed =
-		(document.fullscreenEnabled || document.webkitFullscreenEnabled) &&
-		enableFullScreenToggleButton;
+		(document.fullscreenEnabled || document.webkitFullscreenEnabled) && enableFullScreen;
 
 	return (
 		<div
@@ -229,7 +228,7 @@ Carousel.propTypes = {
 	/** Used to set a custom full screen exit button, cloned with event handlers */
 	fullScreenMinimizeButton: PropTypes.node,
 	/** Opt into showing a full screen toggle button. Uses defaults if no `fullScreenShowButton` or `fullScreenMinimizeButton` provided for respective button states */
-	enableFullScreenToggleButton: PropTypes.bool,
+	enableFullScreen: PropTypes.bool,
 };
 
 export default Carousel;

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -29,6 +29,7 @@ const DefaultPreviousButton = ({ id, onClick }) => (
 	</Button>
 );
 
+/* istanbul ignore next  */
 const DefaultExitFullScreenButton = ({ id, onClick }) => (
 	<Button
 		id={id}
@@ -99,6 +100,7 @@ const Carousel = ({
 		setPosition(position - 100 / slidesToShow);
 	};
 
+	/* istanbul ignore next  */
 	const toggleFullScreen = () => {
 		// id is the carousel id
 		// the full screen element is the whole carousel
@@ -179,6 +181,7 @@ const Carousel = ({
 		<DefaultExitFullScreenButton id={id} onClick={toggleFullScreen} />
 	);
 
+	/* istanbul ignore next  */
 	const fullScreenEnabledAllowed =
 		(document.fullscreenEnabled || document.webkitFullscreenEnabled) && enableFullScreen;
 
@@ -203,7 +206,11 @@ const Carousel = ({
 			<div className="c-carousel__actions">
 				{/* only show button at all if enabled on the document */}
 				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
-				{fullScreenEnabledAllowed && isFullScreen ? resolvedFullScreenMinimizeButton : null}
+				{
+					/* istanbul ignore next  */ fullScreenEnabledAllowed && isFullScreen
+						? resolvedFullScreenMinimizeButton
+						: null
+				}
 				{slide !== slidesToShow ? resolvedPreviousButton : null}
 				{slide !== carouselItems.length && carouselItems.length > 1 ? resolvedNextButton : null}
 			</div>

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -196,6 +196,15 @@ const Carousel = ({
 			style={{ "--carousel-slide-width": slidesToShow !== 4 ? `${100 / slidesToShow}%` : null }}
 			{...handlers}
 		>
+			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
+				{/* only show button at all if enabled on the document */}
+				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
+				{
+					/* istanbul ignore next  */ fullScreenEnabledAllowed && isFullScreen
+						? resolvedFullScreenMinimizeButton
+						: null
+				}
+			</div>
 			<div
 				className="c-carousel__track"
 				style={{ transform: `translate3d(${position}%, 0px, 0px)` }}
@@ -204,13 +213,6 @@ const Carousel = ({
 			</div>
 
 			<div className="c-carousel__actions">
-				{/* only show button at all if enabled on the document */}
-				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
-				{
-					/* istanbul ignore next  */ fullScreenEnabledAllowed && isFullScreen
-						? resolvedFullScreenMinimizeButton
-						: null
-				}
 				{slide !== slidesToShow ? resolvedPreviousButton : null}
 				{slide !== carouselItems.length && carouselItems.length > 1 ? resolvedNextButton : null}
 			</div>

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -169,6 +169,10 @@ const Carousel = ({
 		</button>
 	);
 
+	const fullScreenEnabledAllowed =
+		(document.fullscreenEnabled || document.webkitFullscreenEnabled) &&
+		enableFullScreenToggleButton;
+
 	return (
 		<div
 			{...rest}
@@ -188,8 +192,9 @@ const Carousel = ({
 			</div>
 
 			<div className="c-carousel__actions">
-				{enableFullScreenToggleButton && !isFullScreen ? resolvedFullScreenShowButton : null}
-				{enableFullScreenToggleButton && isFullScreen ? resolvedFullScreenMinimizeButton : null}
+				{/* only show button at all if enabled on the document */}
+				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
+				{fullScreenEnabledAllowed && isFullScreen ? resolvedFullScreenMinimizeButton : null}
 				{slide !== slidesToShow ? resolvedPreviousButton : null}
 				{slide !== carouselItems.length && carouselItems.length > 1 ? resolvedNextButton : null}
 			</div>

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -86,14 +86,15 @@ const Carousel = ({
 			} else {
 				document.exitFullscreen().then(() => setIsFullScreen(false));
 			}
-		}
-
-		// safari needs prefix
-		if (document.webkitFullscreenEnabled) {
-			if (!document.webkitFullscreenElement) {
-				fullScreenElement.webkitRequestFullscreen().then(() => setIsFullScreen(true));
-			} else {
-				document.webkitExitFullscreen().then(() => setIsFullScreen(false));
+		} else {
+			// safari needs prefix
+			// eslint-disable-next-line no-lonely-if
+			if (document.webkitFullscreenEnabled) {
+				if (!document.webkitFullscreenElement) {
+					fullScreenElement.webkitRequestFullscreen().then(() => setIsFullScreen(true));
+				} else {
+					document.webkitExitFullscreen().then(() => setIsFullScreen(false));
+				}
 			}
 		}
 	};

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -29,23 +29,23 @@ const DefaultPreviousButton = ({ id, onClick }) => (
 	</Button>
 );
 
-const DefaultMinimizeScreenButton = ({ id, onClick }) => (
+const DefaultExitFullScreenButton = ({ id, onClick }) => (
 	<Button
 		id={id}
 		onClick={onClick}
 		label="Exit full screen mode displaying the carousel"
-		className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--exit-full-screen`}
 	>
 		Minimize Screen
 	</Button>
 );
 
-const DefaultShowScreenButton = ({ id, onClick }) => (
+const DefaultEnterFullScreenButton = ({ id, onClick }) => (
 	<Button
 		id={id}
 		onClick={onClick}
 		label="Enter full screen mode displaying the carousel"
-		className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--enter-full-screen`}
 	>
 		Full Screen
 	</Button>
@@ -164,19 +164,19 @@ const Carousel = ({
 	const resolvedFullScreenShowButton = fullScreenShowButton ? (
 		cloneElement(fullScreenShowButton, {
 			onClick: toggleFullScreen,
-			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenShowButton.props?.className}`,
+			className: `${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--enter-full-screen ${fullScreenShowButton.props?.className}`,
 		})
 	) : (
-		<DefaultShowScreenButton id={id} onClick={toggleFullScreen} />
+		<DefaultEnterFullScreenButton id={id} onClick={toggleFullScreen} />
 	);
 
 	const resolvedFullScreenMinimizeButton = fullScreenMinimizeButton ? (
 		cloneElement(fullScreenMinimizeButton, {
 			onClick: toggleFullScreen,
-			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenMinimizeButton.props?.className}`,
+			className: `${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--enter-full-screen ${fullScreenMinimizeButton.props?.className}`,
 		})
 	) : (
-		<DefaultMinimizeScreenButton id={id} onClick={toggleFullScreen} />
+		<DefaultExitFullScreenButton id={id} onClick={toggleFullScreen} />
 	);
 
 	const fullScreenEnabledAllowed =

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -37,10 +37,15 @@ const Carousel = ({
 	nextButton,
 	previousButton,
 	slidesToShow,
+	fullScreenShowButton,
+	fullScreenMinimizeButton,
+	enableFullScreenToggleButton,
 	...rest
 }) => {
 	const [slide, setSlide] = useState(slidesToShow);
 	const [position, setPosition] = useState(0);
+	const [isFullScreen, setIsFullScreen] = useState(false);
+
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
 	const subComponents = Object.values(Carousel).map((subcomponentType) =>
@@ -68,6 +73,29 @@ const Carousel = ({
 		}
 		setSlide(slide + 1);
 		setPosition(position - 100 / slidesToShow);
+	};
+
+	const toggleFullScreen = () => {
+		// id is the carousel id
+		// the full screen element is the whole carousel
+		const fullScreenElement = document.getElementById(id);
+
+		if (document.fullscreenEnabled) {
+			if (!document.fullscreenElement) {
+				fullScreenElement.requestFullscreen().then(() => setIsFullScreen(true));
+			} else {
+				document.exitFullscreen().then(() => setIsFullScreen(false));
+			}
+		}
+
+		// safari needs prefix
+		if (document.webkitFullscreenEnabled) {
+			if (!document.webkitFullscreenElement) {
+				fullScreenElement.webkitRequestFullscreen().then(() => setIsFullScreen(true));
+			} else {
+				document.webkitExitFullscreen().then(() => setIsFullScreen(false));
+			}
+		}
 	};
 
 	/* istanbul ignore next */
@@ -108,6 +136,36 @@ const Carousel = ({
 		<DefaultPreviousButton id={id} onClick={() => previousSlide()} />
 	);
 
+	const resolvedFullScreenShowButton = fullScreenShowButton ? (
+		cloneElement(fullScreenShowButton, {
+			onClick: toggleFullScreen,
+			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenShowButton.props?.className}`,
+		})
+	) : (
+		<button
+			onClick={toggleFullScreen}
+			type="button"
+			className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+		>
+			Full Screen
+		</button>
+	);
+
+	const resolvedFullScreenMinimizeButton = fullScreenMinimizeButton ? (
+		cloneElement(fullScreenMinimizeButton, {
+			onClick: toggleFullScreen,
+			className: `${COMPONENT_CLASS_NAME}__full-screen-toggle ${fullScreenMinimizeButton.props?.className}`,
+		})
+	) : (
+		<button
+			onClick={toggleFullScreen}
+			type="button"
+			className={`${COMPONENT_CLASS_NAME}__full-screen-toggle`}
+		>
+			Minimize Screen
+		</button>
+	);
+
 	return (
 		<div
 			{...rest}
@@ -127,6 +185,8 @@ const Carousel = ({
 			</div>
 
 			<div className="c-carousel__actions">
+				{enableFullScreenToggleButton && !isFullScreen ? resolvedFullScreenShowButton : null}
+				{enableFullScreenToggleButton && isFullScreen ? resolvedFullScreenMinimizeButton : null}
 				{slide !== slidesToShow ? resolvedPreviousButton : null}
 				{slide !== carouselItems.length ? resolvedNextButton : null}
 			</div>
@@ -134,7 +194,6 @@ const Carousel = ({
 	);
 };
 
-Carousel.Button = Button;
 Carousel.Item = Item;
 
 Carousel.defaultProps = {
@@ -156,6 +215,12 @@ Carousel.propTypes = {
 	nextButton: PropTypes.node,
 	/** Number of slides to show in view */
 	slidesToShow: PropTypes.number,
+	/** Used to set a custom full screen show button, cloned with event handlers */
+	fullScreenShowButton: PropTypes.node,
+	/** Used to set a custom full screen exit button, cloned with event handlers */
+	fullScreenMinimizeButton: PropTypes.node,
+	/** Opt into showing a full screen toggle button. Uses defaults if no `fullScreenShowButton` or `fullScreenMinimizeButton` provided for respective button states */
+	enableFullScreenToggleButton: PropTypes.bool,
 };
 
 export default Carousel;

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -187,7 +187,7 @@ const Feature = () => (
 
 <Canvas>
 	<Story name="Show Full Screen Toggle">
-		<Carousel id="carousel-1" label="Carousel of Images" enableFullScreenToggleButton>
+		<Carousel id="carousel-1" label="Carousel of Images" enableFullScreen>
 			<Carousel.Item label="Slide 1 of 1">
 				<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
 			</Carousel.Item>
@@ -202,7 +202,7 @@ const Feature = () => (
 		<Carousel
 			id="carousel-1"
 			label="Carousel of Images"
-			enableFullScreenToggleButton
+			enableFullScreen
 			fullScreenShowButton={
 				<button type="button">
 					<Icon name="Fullscreen" />
@@ -230,7 +230,7 @@ const Feature = () => (
 			id="carousel-1"
 			label="Carousel of Images"
 			slidesToShow={1}
-			enableFullScreenToggleButton
+			enableFullScreen
 			fullScreenShowButton={
 				<button type="button">
 					<Icon name="Fullscreen" />

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -15,6 +15,8 @@ A slideshow component that allows for the ability to display more items than can
 on a screen and allow the user to navigate through the items using buttons and/or
 touch interactions.
 
+The slideshow component also allows users to toggle full screen mode. The full-screen functionality uses the Fullscreen API, which all modern browsers [support](https://caniuse.com/fullscreen).
+
 ## Usage
 
 ```jsx
@@ -127,6 +129,45 @@ const Feature = () => (
 				<a href="/">
 					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
 				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>
+
+** Show Full Screen Toggle **
+
+<Canvas>
+	<Story name="Show Full Screen Toggle">
+		<Carousel id="carousel-1" label="Carousel of Images" enableFullScreenToggleButton>
+			<Carousel.Item label="Slide 1 of 1">
+				<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>
+
+** Show Custom Full Screen Toggle **
+
+<Canvas>
+	<Story name="Show Custom Full Screen Toggle">
+		<Carousel
+			id="carousel-1"
+			label="Carousel of Images"
+			enableFullScreenToggleButton
+			fullScreenShowButton={
+				<button type="button">
+					<Icon name="Fullscreen" />
+					Expand
+				</button>
+			}
+			fullScreenMinimizeButton={
+				<button type="button">
+					<Icon name="Close" />
+				</button>
+			}
+		>
+			<Carousel.Item label="Slide 1 of 1">
+				<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
 			</Carousel.Item>
 		</Carousel>
 	</Story>

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -217,4 +217,44 @@ describe("Carousel", () => {
 		await userEvent.click(screen.getByRole("button", { name: "Previous" }));
 		expect(prevEvent).toHaveBeenCalled();
 	});
+
+	it("should show full-screen button if full screen option enabled and use custom button", async () => {
+		render(
+			<Carousel
+				id="carousel-2"
+				label="Carousel Label"
+				fullScreenShowButton={<button type="button">Show Custom Full Screen</button>}
+				fullScreenMinimizeButton={<button type="button">Hide Custom Full Screen</button>}
+				enableFullScreenToggleButton
+			>
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		expect(screen.queryAllByText("Show Custom Full Screen")).toHaveLength(1);
+	});
+	it("should show full-screen button if full screen option enabled and use default button", async () => {
+		render(
+			<Carousel id="carousel-2" label="Carousel Label" enableFullScreenToggleButton>
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		expect(screen.queryAllByText("Full Screen")).toHaveLength(1);
+	});
+	it("does not show full screen button default if disabled", () => {
+		render(
+			<Carousel id="carousel-2" label="Carousel Label">
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		expect(screen.queryAllByText("Full Screen")).toHaveLength(0);
+	});
 });

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -3,6 +3,11 @@ import userEvent from "@testing-library/user-event";
 
 import Carousel from ".";
 
+// define full screen like in browsers that support full screen api
+Object.defineProperty(global.document, "fullscreenEnabled", {
+	value: true,
+});
+
 describe("Carousel", () => {
 	it("should render carousel", () => {
 		render(
@@ -254,7 +259,7 @@ describe("Carousel", () => {
 				label="Carousel Label"
 				fullScreenShowButton={<button type="button">Show Custom Full Screen</button>}
 				fullScreenMinimizeButton={<button type="button">Hide Custom Full Screen</button>}
-				enableFullScreenToggleButton
+				enableFullScreen
 			>
 				<Carousel.Item label="Slide 1 of 5">
 					<div />
@@ -266,7 +271,7 @@ describe("Carousel", () => {
 	});
 	it("should show full-screen button if full screen option enabled and use default button", async () => {
 		render(
-			<Carousel id="carousel-2" label="Carousel Label" enableFullScreenToggleButton>
+			<Carousel id="carousel-2" label="Carousel Label" enableFullScreen>
 				<Carousel.Item label="Slide 1 of 5">
 					<div />
 				</Carousel.Item>


### PR DESCRIPTION
## Ticket

- [TMEDIA-834](https://arcpublishing.atlassian.net/browse/TMEDIA-834) subtask of [TMEDIA-689](https://arcpublishing.atlassian.net/browse/TMEDIA-689)

## Description

Use full screen for carousel. 

Note: I could not mock requestFullscreen on the the target element without potentially introducing bugs into our component itself. Let me know if you have suggestions. I was able to mock on the document but didn't on individual tests. 

Also note: this has limited support on safari ios. It works on ipad but not iphones safari. 

## Acceptance Criteria

- Hide the full screen button if browser api doesn't support it 
- Is accessible. Includes aria-label and aria-controls like existing buttons in this component 
- Allows enough customization and configuration 

## Test Steps

1. Checkout branch - `git checkout TMEDIA-834-toggle-full-screen`
2. Run Storybook `npm run storybook`
3. Go to a chromium browser with the carousel storybook http://localhost:60003/?path=/story/components-carousel--show-full-screen-toggle
4. Click "Full Screen" default button
5. See the carousel go full-screen
6. Click "Minimize Screen" default button to exit full screen
7. Click "Full Screen" default button again
8. Now exit full-screen by pressing escape on a mac or `f11` on pc https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API/Guide#things_your_users_want_to_know
9. Go to another example utilizing custom enter and exit full-screen buttons http://localhost:60003/?path=/story/components-carousel--show-custom-full-screen-toggle

<img width="1437" alt="Screen Shot 2022-04-15 at 09 44 19" src="https://user-images.githubusercontent.com/5950956/163584827-8d3f7a81-f2c3-4dc3-8f59-9669a27c35a8.png">
<img width="729" alt="Screen Shot 2022-04-15 at 09 44 30" src="https://user-images.githubusercontent.com/5950956/163584826-9764fae7-6d50-46c0-adab-c3747aa872c1.png">


10. Repeat open and close 
11.  Go to carousel with multiple images http://localhost:60003/?path=/story/components-carousel--show-custom-full-screen-toggle-with-multiple-slides
12. Open the carousel
13. Now ensure that you can still go to next and previous photos 
14. Notice the classes include the `c-carousel__button` class as well as corresponding modifiers for open and close full-screen mode classes c-carousel__button c-carousel__button--enter-full-screen
15. Repeat steps of opening and closing on safari on mac
16. Repeat steps of opening and closing on safari for ipad. I used a simulator. (You'll notice that in the top-left corner there's an "x" that can't be removed according to the spec.) 
![image](https://user-images.githubusercontent.com/5950956/163261910-d0ff42d5-f297-4faf-ac2a-f412d333db6d.png)
17. You can test if this shows on safari, for instance, by removing the safari webkit check for rendering the buttons. Then running in safari. You won't see the button if you modify 
```js
	const fullScreenEnabledAllowed =
		(document.fullscreenEnabled || document.webkitFullscreenEnabled) && enableFullScreen;

```
to 
```js
	const fullScreenEnabledAllowed =
		(document.fullscreenEnabled /* ||  document.webkitFullscreenEnabled */) && enableFullScreen;
```
## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**

----

## Questions 

- Is providing the custom button props and enable ok for the usecases? -> yes, follows existing pattern in component
- Is the behavior for showing and hiding full-screen what we want? You can test this on chromium or blink(safari) browsers.  -> Product says this is ok.
- Is the accessibility of this as expected? I wasn't sure if we needed/wanted an aria label for toggling screen; seemed unnecessary. -> There still are accessible reasons for this to exist. Updated based on best practices within this repo.

## Todos 

- [ ] Add event handler tests for the button -> can't really do this without hacking the component

## Notes 

- I'm splitting this ticket up into sub-tasks for clarity on my end https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-689&assignee=5e387d6a1b1d910e5dfd7a9b
- Can be tested with `npm run storybook` and going to carousel custom full screen and default

