### PR TITLE
Carousel CSS Updates

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-git fetch -a --depth 100 && npm run lint:changed-feature-branch && npm run test:changed-feature-branch
+git fetch -a --depth 100 && npm run lint:changed-feature-branch && npm run lint:styles && npm run test:changed-feature-branch

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -5,7 +5,6 @@
 
 	display: grid;
 	grid-template-areas: "carousel";
-	justify-content: center;
 	overflow: hidden;
 
 	@include scss.component-properties("carousel");
@@ -15,7 +14,9 @@
 	}
 
 	&__track {
+		--slide-gap: var(--c-carousel-track-gap, 0px);
 		display: flex;
+		justify-self: center;
 		transition: transform 0.4s ease-in;
 		will-change: transform;
 
@@ -23,7 +24,7 @@
 	}
 
 	&__slide {
-		flex: 0 0 var(--slide-width);
+		flex: 0 0 calc(var(--slide-width) - var(--slide-gap));
 
 		@include scss.component-properties("carousel-slide");
 	}

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -15,6 +15,7 @@
 
 	&__track {
 		/* stylelint-disable length-zero-no-unit */
+		// Disabled the rule as the px value is needed within the calc below
 		--slide-gap: var(--c-carousel-track-gap, 0px);
 		display: flex;
 		justify-self: center;

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -14,6 +14,7 @@
 	}
 
 	&__track {
+		/* stylelint-disable length-zero-no-unit */
 		--slide-gap: var(--c-carousel-track-gap, 0px);
 		display: flex;
 		justify-self: center;


### PR DESCRIPTION
## Description

Update justify-content property and account for slide gap in slide flex width

Having the `justify-content` property on the root carousel class does not allow for the buttons to go beyond the track if you specify a max-width for the track.

Added a `calc` to account for setting a `gap` value on the carousel track when you want to provide spacing between carousel items

## Test Steps

1. Checkout branch - `git checkout carousel-css-update`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed relevant documentation has been updated/added.
- [ ] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
