### PR TITLE
Add break-word to carousel component as default

### DIFF
--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -6,6 +6,7 @@
 	display: grid;
 	grid-template-areas: "carousel";
 	overflow: hidden;
+	word-break: break-word;
 
 	@include scss.component-properties("carousel");
 


### PR DESCRIPTION
## Description

Add `word-break: break-word` to carousel default CSS as per team findings during pairing

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
