### PR TITLE
Tmedia 836 label counter

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -21,6 +21,12 @@
 					height: auto,
 					width: 1px,
 				),
+				carousel-image-counter: (
+					color: #191919,
+				),
+				carousel-fullscreen-image-counter: (
+					color: white,
+				),
 			),
 		),
 	)

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -14,6 +14,16 @@
 		grid-area: carousel;
 	}
 
+	&:fullscreen {
+		@include scss.component-properties("carousel-fullscreen");
+
+		// setting fullscreen status for counter label
+		// overrides counter label styles
+		.c-carousel__image-counter-label {
+			@include scss.component-properties("carousel-fullscreen-image-counter");
+		}
+	}
+
 	&__track {
 		/* stylelint-disable length-zero-no-unit */
 		// Disabled the rule as the px value is needed within the calc below
@@ -76,5 +86,10 @@
 
 	&__image-counter-label {
 		@include scss.component-properties("carousel-image-counter");
+	}
+
+	// add backdrop for setting full-screen background-color
+	&::backdrop {
+		@include scss.component-properties("carousel-backdrop");
 	}
 }

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -4,7 +4,7 @@
 	--slide-width: var(--carousel-slide-width, 25%);
 
 	display: grid;
-	grid-template-areas: "carousel";
+	grid-template-areas: "top-actions" "carousel";
 	overflow: hidden;
 	word-break: break-word;
 
@@ -42,6 +42,11 @@
 		@include scss.component-properties("carousel-actions");
 	}
 
+	&__top-actions {
+		grid-area: top-actions;
+		@include scss.component-properties("carousel-top-actions");
+	}
+
 	&__button {
 		@include scss.component-properties("carousel-button");
 
@@ -54,5 +59,9 @@
 		&--previous {
 			@include scss.component-properties("carousel-button-previous");
 		}
+	}
+
+	&__image-counter-label {
+		@include scss.component-properties("carousel-image-counter");
 	}
 }

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -14,6 +14,10 @@
 		grid-area: carousel;
 	}
 
+	&__image-counter-label {
+		@include scss.component-properties("carousel-image-counter");
+	}
+
 	&:fullscreen {
 		@include scss.component-properties("carousel-fullscreen");
 
@@ -82,10 +86,6 @@
 		&--exit-full-screen {
 			@include scss.component-properties("carousel-button-exit-full-screen");
 		}
-	}
-
-	&__image-counter-label {
-		@include scss.component-properties("carousel-image-counter");
 	}
 
 	// add backdrop for setting full-screen background-color

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -4,7 +4,7 @@
 	--slide-width: var(--carousel-slide-width, 25%);
 
 	display: grid;
-	grid-template-areas: "top-actions" "carousel";
+	grid-template-areas: "controls" "carousel";
 	overflow: hidden;
 	word-break: break-word;
 
@@ -56,14 +56,14 @@
 		@include scss.component-properties("carousel-actions");
 	}
 
-	&__top-actions {
-		grid-area: top-actions;
+	&__controls {
+		grid-area: controls;
 		display: flex;
 		justify-content: space-between;
 		place-self: start;
 		width: 100%;
 
-		@include scss.component-properties("carousel-top-actions");
+		@include scss.component-properties("carousel-controls");
 	}
 
 	&__button {

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -44,6 +44,11 @@
 
 	&__top-actions {
 		grid-area: top-actions;
+		display: flex;
+		justify-content: space-between;
+		place-self: start;
+		width: 100%;
+
 		@include scss.component-properties("carousel-top-actions");
 	}
 

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -77,10 +77,11 @@ const Carousel = ({
 	enableFullScreen,
 	...rest
 }) => {
+	// slidesToShow is a number of slides to show at once
 	const [slide, setSlide] = useState(slidesToShow);
 	const [position, setPosition] = useState(0);
 	const [isFullScreen, setIsFullScreen] = useState(false);
-
+	const totalSlides = Children.count(children);
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
 	const subComponents = Object.values(Carousel).map((subcomponentType) =>
@@ -195,7 +196,9 @@ const Carousel = ({
 			{...handlers}
 		>
 			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
-				<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>Label</p>
+				<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
+					{slide} of {totalSlides}
+				</p>
 				{/* only show button at all if enabled on the document */}
 				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
 				{

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -70,6 +70,7 @@ const Carousel = ({
 	id,
 	label,
 	nextButton,
+	pageCountPhrase,
 	previousButton,
 	showLabel,
 	slidesToShow,
@@ -199,7 +200,7 @@ const Carousel = ({
 			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
 				{showLabel ? (
 					<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
-						{slide} of {totalSlides}
+						{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
 					</p>
 				) : null}
 				{/* only show button at all if enabled on the document */}
@@ -229,8 +230,9 @@ Carousel.Button = Button;
 Carousel.Item = Item;
 
 Carousel.defaultProps = {
-	slidesToShow: 4,
+	pageCountPhrase: () => {},
 	showLabel: false,
+	slidesToShow: 4,
 };
 
 Carousel.propTypes = {
@@ -242,6 +244,8 @@ Carousel.propTypes = {
 	id: PropTypes.string.isRequired,
 	/** An accessible label */
 	label: PropTypes.string.isRequired,
+	/** Page count phrase text for internationalization, function takes in current, total */
+	pageCountPhrase: PropTypes.func,
 	/** Used to set a custom previous button, a cloned Carousel.Button element */
 	previousButton: PropTypes.node,
 	/** Used to set a custom next button, a cloned Carousel.Button element */

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -71,6 +71,7 @@ const Carousel = ({
 	label,
 	nextButton,
 	previousButton,
+	showLabel,
 	slidesToShow,
 	fullScreenShowButton,
 	fullScreenMinimizeButton,
@@ -196,9 +197,11 @@ const Carousel = ({
 			{...handlers}
 		>
 			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
-				<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
-					{slide} of {totalSlides}
-				</p>
+				{showLabel ? (
+					<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
+						{slide} of {totalSlides}
+					</p>
+				) : null}
 				{/* only show button at all if enabled on the document */}
 				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
 				{
@@ -227,6 +230,7 @@ Carousel.Item = Item;
 
 Carousel.defaultProps = {
 	slidesToShow: 4,
+	showLabel: false,
 };
 
 Carousel.propTypes = {
@@ -250,6 +254,8 @@ Carousel.propTypes = {
 	fullScreenMinimizeButton: PropTypes.node,
 	/** Opt into showing a full screen toggle button. Uses defaults if no `fullScreenShowButton` or `fullScreenMinimizeButton` provided for respective button states */
 	enableFullScreen: PropTypes.bool,
+	/** Show the current slide number */
+	showLabel: PropTypes.bool,
 };
 
 export default Carousel;

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -115,6 +115,9 @@ const Carousel = ({
 			style={{ "--carousel-slide-width": slidesToShow !== 4 ? `${100 / slidesToShow}%` : null }}
 			{...handlers}
 		>
+			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
+				<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>Label</p>
+			</div>
 			<div
 				className="c-carousel__track"
 				style={{ transform: `translate3d(${position}%, 0px, 0px)` }}

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -197,7 +197,7 @@ const Carousel = ({
 			style={{ "--carousel-slide-width": slidesToShow !== 4 ? `${100 / slidesToShow}%` : null }}
 			{...handlers}
 		>
-			<div className={`${COMPONENT_CLASS_NAME}__top-actions`}>
+			<div className={`${COMPONENT_CLASS_NAME}__controls`}>
 				{showLabel ? (
 					<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
 						{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -250,6 +250,8 @@ Carousel.propTypes = {
 	previousButton: PropTypes.node,
 	/** Used to set a custom next button, a cloned Carousel.Button element */
 	nextButton: PropTypes.node,
+	/** Show the current slide number */
+	showLabel: PropTypes.bool,
 	/** Number of slides to show in view */
 	slidesToShow: PropTypes.number,
 	/** Used to set a custom full screen show button, cloned with event handlers */
@@ -258,8 +260,6 @@ Carousel.propTypes = {
 	fullScreenMinimizeButton: PropTypes.node,
 	/** Opt into showing a full screen toggle button. Uses defaults if no `fullScreenShowButton` or `fullScreenMinimizeButton` provided for respective button states */
 	enableFullScreen: PropTypes.bool,
-	/** Show the current slide number */
-	showLabel: PropTypes.bool,
 };
 
 export default Carousel;

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -212,13 +212,13 @@ const Carousel = ({
 				}
 			</div>
 			<div
-				className="c-carousel__track"
+				className={`${COMPONENT_CLASS_NAME}__track`}
 				style={{ transform: `translate3d(${position}%, 0px, 0px)` }}
 			>
 				{carouselItems.map((component) => component)}
 			</div>
 
-			<div className="c-carousel__actions">
+			<div className={`${COMPONENT_CLASS_NAME}__actions`}>
 				{slide !== slidesToShow ? resolvedPreviousButton : null}
 				{slide !== carouselItems.length && carouselItems.length > 1 ? resolvedNextButton : null}
 			</div>

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -215,7 +215,7 @@ const Feature = () => (
 
 <Canvas>
 	<Story name="Show Full Screen Toggle">
-		<Carousel slidesToShow={1} id="carousel-1" label="Carousel of Images" enableFullScreen>
+		<Carousel id="carousel-1" label="Carousel of Images" enableFullScreen>
 			<Carousel.Item label="Slide 1 of 1">
 				<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
 			</Carousel.Item>

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -327,3 +327,38 @@ const Feature = () => (
 		</Carousel>
 	</Story>
 </Canvas>
+
+** Show Custom Label Text **
+
+<Canvas>
+	<Story name="Show Custom Label Text">
+		<Carousel
+			id="carousel-1"
+			label="Carousel of Images"
+			slidesToShow={1}
+			showLabel
+			enableFullScreen
+			pageCountPhrase={(current, total) => `${current} of ${total} cool images`}
+		>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+			<Carousel.Item label="Slide 2 of 5">
+				<Image src="/camera.jpeg" alt="A camera with photos in front of it" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 3 of 5">
+				<Image src="/canyon.jpeg" alt="Landscape view of a canyon" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 4 of 5">
+				<Image src="/coffee.jpeg" alt="A cup of coffee" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 5 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -183,6 +183,34 @@ const Feature = () => (
 	</Story>
 </Canvas>
 
+** With Label And Multiple Slides **
+
+<Canvas>
+	<Story name="With Label And Multiple Slides Showing One">
+		<Carousel id="carousel-1" label="Carousel of Images" showLabel slidesToShow={1}>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+			<Carousel.Item label="Slide 2 of 5">
+				<Image src="/camera.jpeg" alt="A camera with photos in front of it" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 3 of 5">
+				<Image src="/canyon.jpeg" alt="Landscape view of a canyon" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 4 of 5">
+				<Image src="/coffee.jpeg" alt="A cup of coffee" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 5 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>
+
 ** Show Full Screen Toggle **
 
 <Canvas>
@@ -243,6 +271,40 @@ const Feature = () => (
 					<Icon name="Close" />
 				</button>
 			}
+		>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+			<Carousel.Item label="Slide 2 of 5">
+				<Image src="/camera.jpeg" alt="A camera with photos in front of it" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 3 of 5">
+				<Image src="/canyon.jpeg" alt="Landscape view of a canyon" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 4 of 5">
+				<Image src="/coffee.jpeg" alt="A cup of coffee" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 5 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>
+
+** Show With Label And Full Screen Toggle With Multiple Slides **
+
+<Canvas>
+	<Story name="Show With Label And Full Screen Toggle With Multiple Slides">
+		<Carousel
+			id="carousel-1"
+			label="Carousel of Images"
+			slidesToShow={1}
+			showLabel
+			enableFullScreen
 		>
 			<Carousel.Item label="Slide 1 of 5">
 				<a href="/">

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -230,7 +230,6 @@ const Feature = () => (
 		<Carousel
 			id="carousel-1"
 			label="Carousel of Images"
-			slidesToShow={1}
 			enableFullScreen
 			fullScreenShowButton={
 				<button type="button">

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -187,7 +187,7 @@ const Feature = () => (
 
 <Canvas>
 	<Story name="Show Full Screen Toggle">
-		<Carousel id="carousel-1" label="Carousel of Images" enableFullScreen>
+		<Carousel slidesToShow={1} id="carousel-1" label="Carousel of Images" enableFullScreen>
 			<Carousel.Item label="Slide 1 of 1">
 				<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
 			</Carousel.Item>
@@ -202,6 +202,7 @@ const Feature = () => (
 		<Carousel
 			id="carousel-1"
 			label="Carousel of Images"
+			slidesToShow={1}
 			enableFullScreen
 			fullScreenShowButton={
 				<button type="button">

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -291,4 +291,58 @@ describe("Carousel", () => {
 
 		expect(screen.queryAllByText("Full Screen")).toHaveLength(0);
 	});
+
+	it("shows label if opted in", () => {
+		render(
+			<Carousel id="carousel-2" label="Carousel Label" showLabel slidesToShow={1}>
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+		// query by text returns null if not found
+		const foundLabel = screen.queryByText("1 of 2");
+		expect(foundLabel).not.toBeNull();
+	});
+	it("does not show label if not opted in", () => {
+		render(
+			<Carousel id="carousel-2" label="Carousel Label" slidesToShow={1}>
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+		// query by text returns null if not found
+		const foundLabel = screen.queryByText("1 of 2");
+		expect(foundLabel).toBeNull();
+	});
+	it("shows custom label text if opted in and provides function", () => {
+		render(
+			<Carousel
+				id="carousel-2"
+				label="Carousel Label"
+				showLabel
+				slidesToShow={1}
+				pageCountPhrase={(currentSlide, totalSlides) =>
+					`${currentSlide} of ${totalSlides} super cool images`
+				}
+			>
+				<Carousel.Item label="Slide 1 of 5">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 5">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+		// query by text returns null if not found
+		const foundLabel = screen.queryByText("1 of 2 super cool images");
+		expect(foundLabel).not.toBeNull();
+	});
 });


### PR DESCRIPTION
## Ticket

- [TMEDIA-836](https://arcpublishing.atlassian.net/browse/TMEDIA-836)

## Description

use label counter similar to previous implementation

## Acceptance Criteria

- Image counter (i.e. 1 of 15). The counter is labelled on the carousel

## Test Steps

1. Checkout branch - `git checkout TMEDIA-836-label-counter`
2. Run Storybook `npm run storybook`
3. Check out the button storybook documentation. Go to the carousel stories 
4. Notice the label set in the story 
![Screen Shot 2022-04-18 at 10 13 03](https://user-images.githubusercontent.com/5950956/163829582-3d6f0400-a308-4c8e-9709-1e12ef94fadc.png)
5. Click "next" button and notice the label change 
![Screen Shot 2022-04-18 at 10 14 01](https://user-images.githubusercontent.com/5950956/163829659-4faaac44-aee4-4703-a74b-490e40fac607.png)
6. Go full screen by clicking the "Full Screen" button in the Commerce theme 
![Screen Shot 2022-04-18 at 10 15 04](https://user-images.githubusercontent.com/5950956/163829806-633a13c6-bbdc-46a4-a26b-e161d75b75a3.png)
7. Notice how the label text is still visible when this pseudo class of full screen is applied 
![Screen Shot 2022-04-18 at 10 15 54](https://user-images.githubusercontent.com/5950956/163829926-f73b3b1b-78ec-4d14-8711-48e0b55b37f0.png)
8. Exit full screen mode by clicking "Minimize screen" 
9. In the implementation, I've allowed the label text to be modified out of full screen and within. Furthermore, if the user wants to customize the backdrop pseudoelement in full-screen mode, then they could ensure that the text is visible on whatever background color is used with ::backdrop
10. In another story, go to the custom label text. This allows the user to provide a function if available to give internationalized or custom text. This is based off of the engine theme sdk implementation. Notice how this one says "cool images". It will work the same as before
![Screen Shot 2022-04-18 at 10 18 03](https://user-images.githubusercontent.com/5950956/163830222-fb2ece13-6d28-44f3-853d-f7b8932e348a.png)
11. Also, since this is opt-in functionality, no label is shown by default on other stories

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**

--------

## Notes 

- Working on ensuring styles can be set for children of a full-screened element. Notice the commerce style allowing the label to be set with one color for not-fullscreen and the other for full-screen. That backdrop can be different colors for different operating systems, browsers
- Added a backdrop for more customization for that as well
- Noticed that slides state variable could track current slide as long as the slides to show does not exceed the slides within. The default value for slides to show is 4 (I might expect 1 for minimum label functionality). 
- Making label opt-in because this is extending the carousel existing functionality

## Questions 

- In terms of internalization and customization, hard-coding "of" is likely not best for the label. Should I pass in the word divider ("of")? or format ("%current off these many %total", "Of %total, you are on %current")? 
-> I can work off the engine-theme-sdk example of setting a default unless a translation is passed in

```
				pageCountPhrase={
							/* istanbul ignore next */ (current, total) =>
								phrases.t("global.gallery-page-count-text", { current, total })
						}

	pageCountPhrase?: (current: number, total: number) => string;

	const ImageCountTextOutput = {
		__html: pageCountPhrase
			? pageCountPhrase(page + 1, galleryElements.length)
			: `<span>Image</span> ${page + 1} of ${galleryElements.length}`,
	};
``` 
- What's the expected behavior for the label with multiple slides showing? With two slides showing, I would expect the global label to say "2 of 5" on first load, right? 
- -> this makes sense to me. This seems to be out of scope for the gallery single slide example