### PR TITLE
Tmedia 838 image arrows counter

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -1,4 +1,8 @@
 @use "../../scss.scss" with (
+	$breakpoints: (
+		default: "min-width: 0",
+		desktop: "min-width: 48rem",
+	),
 	$tokens: (
 		default: (
 			components: (
@@ -26,6 +30,16 @@
 				),
 				carousel-fullscreen-image-counter: (
 					color: white,
+				),
+				carousel-additional-controls: (
+					display: none,
+				),
+			),
+		),
+		desktop: (
+			components: (
+				carousel-additional-controls: (
+					display: block,
 				),
 			),
 		),

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -101,6 +101,14 @@
 		@include scss.component-properties("carousel-additional-controls");
 	}
 
+	&__counter-controls-container {
+		@include scss.component-properties("carousel-counter-controls-container");
+	}
+
+	&__expand-autoplay-container {
+		@include scss.component-properties("carousel-expand-autoplay-container");
+	}
+
 	// add backdrop for setting full-screen background-color
 	&::backdrop {
 		@include scss.component-properties("carousel-backdrop");

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -102,10 +102,14 @@
 	}
 
 	&__counter-controls-container {
+		display: flex;
+		align-items: center;
 		@include scss.component-properties("carousel-counter-controls-container");
 	}
 
 	&__expand-autoplay-container {
+		display: flex;
+		align-items: center;
 		@include scss.component-properties("carousel-expand-autoplay-container");
 	}
 

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -79,6 +79,14 @@
 			@include scss.component-properties("carousel-button-previous");
 		}
 
+		&--additional-previous {
+			@include scss.component-properties("carousel-button-additional-previous");
+		}
+
+		&--additional-next {
+			@include scss.component-properties("carousel-button-additional-next");
+		}
+
 		&--enter-full-screen {
 			@include scss.component-properties("carousel-button-enter-full-screen");
 		}
@@ -86,6 +94,10 @@
 		&--exit-full-screen {
 			@include scss.component-properties("carousel-button-exit-full-screen");
 		}
+	}
+
+	&__additional-controls {
+		@include scss.component-properties("carousel-additional-controls");
 	}
 
 	// add backdrop for setting full-screen background-color

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -279,26 +279,30 @@ const Carousel = ({
 			ref={carouselElement}
 		>
 			<div className={`${COMPONENT_CLASS_NAME}__controls`}>
-				{showLabel ? (
-					<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
-						{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
-					</p>
-				) : null}
-				{showAdditionalSlideControls ? (
-					<div className={`${COMPONENT_CLASS_NAME}__additional-controls`}>
-						{slide !== slidesToShow ? resolvedAdditionalPreviousButton : null}
-						{slide !== carouselItems.length && carouselItems.length > 1
-							? resolvedAdditionalNextButton
-							: null}
-					</div>
-				) : null}
-				{/* only show button at all if enabled on the document */}
-				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
-				{
-					/* istanbul ignore next  */ fullScreenEnabledAllowed && isFullScreen
-						? resolvedFullScreenMinimizeButton
-						: null
-				}
+				<div className={`${COMPONENT_CLASS_NAME}__expand-autoplay-container`}>
+					{/* only show button at all if enabled on the document */}
+					{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
+					{
+						/* istanbul ignore next  */ fullScreenEnabledAllowed && isFullScreen
+							? resolvedFullScreenMinimizeButton
+							: null
+					}
+				</div>
+				<div className={`${COMPONENT_CLASS_NAME}__counter-controls-container`}>
+					{showLabel ? (
+						<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
+							{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
+						</p>
+					) : null}
+					{showAdditionalSlideControls ? (
+						<div className={`${COMPONENT_CLASS_NAME}__additional-controls`}>
+							{slide !== slidesToShow ? resolvedAdditionalPreviousButton : null}
+							{slide !== carouselItems.length && carouselItems.length > 1
+								? resolvedAdditionalNextButton
+								: null}
+						</div>
+					) : null}
+				</div>
 			</div>
 			<div
 				className={`${COMPONENT_CLASS_NAME}__track`}

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -29,6 +29,28 @@ const DefaultPreviousButton = ({ id, onClick }) => (
 	</Button>
 );
 
+const DefaultAdditionalPreviousButton = ({ id, onClick }) => (
+	<Button
+		id={id}
+		onClick={onClick}
+		label="Previous Slide"
+		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--additional-previous`}
+	>
+		{"<"}
+	</Button>
+);
+
+const DefaultAdditionalNextButton = ({ id, onClick }) => (
+	<Button
+		id={id}
+		onClick={onClick}
+		label="Next Slide"
+		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--additional-next`}
+	>
+		{">"}
+	</Button>
+);
+
 /* istanbul ignore next  */
 const DefaultExitFullScreenButton = ({ id, onClick }) => (
 	<Button
@@ -65,6 +87,8 @@ const resolvedButton = (element, id, className, onClick) =>
 	});
 
 const Carousel = ({
+	additionalPreviousButton,
+	additionalNextButton,
 	children,
 	className,
 	id,
@@ -72,6 +96,7 @@ const Carousel = ({
 	nextButton,
 	pageCountPhrase,
 	previousButton,
+	showAdditionalSlideControls,
 	showLabel,
 	slidesToShow,
 	fullScreenShowButton,
@@ -160,6 +185,28 @@ const Carousel = ({
 		<DefaultPreviousButton id={id} onClick={() => previousSlide()} />
 	);
 
+	const resolvedAdditionalNextButton = additionalNextButton ? (
+		resolvedButton(
+			additionalNextButton,
+			id,
+			`${COMPONENT_CLASS_NAME}__button--additional-next`,
+			nextSlide
+		)
+	) : (
+		<DefaultAdditionalNextButton id={id} onClick={nextSlide} />
+	);
+
+	const resolvedAdditionalPreviousButton = additionalPreviousButton ? (
+		resolvedButton(
+			additionalPreviousButton,
+			id,
+			`${COMPONENT_CLASS_NAME}__button--additional-previous`,
+			previousSlide
+		)
+	) : (
+		<DefaultAdditionalPreviousButton id={id} onClick={previousSlide} />
+	);
+
 	const resolvedFullScreenShowButton = fullScreenShowButton ? (
 		resolvedButton(
 			fullScreenShowButton,
@@ -203,6 +250,14 @@ const Carousel = ({
 						{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
 					</p>
 				) : null}
+				{showAdditionalSlideControls ? (
+					<div className={`${COMPONENT_CLASS_NAME}__additional-controls`}>
+						{slide !== slidesToShow ? resolvedAdditionalPreviousButton : null}
+						{slide !== carouselItems.length && carouselItems.length > 1
+							? resolvedAdditionalNextButton
+							: null}
+					</div>
+				) : null}
 				{/* only show button at all if enabled on the document */}
 				{fullScreenEnabledAllowed && !isFullScreen ? resolvedFullScreenShowButton : null}
 				{
@@ -236,6 +291,10 @@ Carousel.defaultProps = {
 };
 
 Carousel.propTypes = {
+	/** Used to set a custom additional next button, a cloned Carousel.Button element */
+	additionalNextButton: PropTypes.node,
+	/** Used to set a custom additional previous button, a cloned Carousel.Button element */
+	additionalPreviousButton: PropTypes.node,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
@@ -250,6 +309,8 @@ Carousel.propTypes = {
 	previousButton: PropTypes.node,
 	/** Used to set a custom next button, a cloned Carousel.Button element */
 	nextButton: PropTypes.node,
+	/** Show next and previous controls in addition to existing ones */
+	showAdditionalSlideControls: PropTypes.bool,
 	/** Show the current slide number */
 	showLabel: PropTypes.bool,
 	/** Number of slides to show in view */

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -1,7 +1,7 @@
 import { Children, cloneElement, useEffect, useRef, useState } from "react";
 import PropTypes from "prop-types";
 import { useSwipeable } from "react-swipeable";
-
+import Icon from "../icon";
 import Button from "./_children/Button";
 import Item from "./_children/Item";
 
@@ -36,7 +36,7 @@ const DefaultAdditionalPreviousButton = ({ id, onClick }) => (
 		label="Previous Slide"
 		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--additional-previous`}
 	>
-		{"<"}
+		<Icon name="ChevronLeft" />
 	</Button>
 );
 
@@ -47,7 +47,7 @@ const DefaultAdditionalNextButton = ({ id, onClick }) => (
 		label="Next Slide"
 		className={`${COMPONENT_CLASS_NAME}__button ${COMPONENT_CLASS_NAME}__button--additional-next`}
 	>
-		{">"}
+		<Icon name="ChevronRight" />
 	</Button>
 );
 

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -362,3 +362,84 @@ const Feature = () => (
 		</Carousel>
 	</Story>
 </Canvas>
+
+** Show additional controls **
+
+<Canvas>
+	<Story name="Show additional controls">
+		<Carousel
+			id="carousel-1"
+			label="Carousel of Images"
+			slidesToShow={1}
+			showLabel
+			showAdditionalSlideControls
+		>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+			<Carousel.Item label="Slide 2 of 5">
+				<Image src="/camera.jpeg" alt="A camera with photos in front of it" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 3 of 5">
+				<Image src="/canyon.jpeg" alt="Landscape view of a canyon" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 4 of 5">
+				<Image src="/coffee.jpeg" alt="A cup of coffee" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 5 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>
+
+** Show additional custom controls and show full screen toggle **
+
+<Canvas>
+	<Story name="Show additional controls and show full screen toggle">
+		<Carousel
+			id="carousel-1"
+			label="Carousel of Images"
+			slidesToShow={1}
+			showLabel
+			showAdditionalSlideControls
+			enableFullScreen
+			additionalNextButton={
+				<button type="button">
+					Custom Next
+					<Icon name="ArrowRight" fill="green" />
+				</button>
+			}
+			additionalPreviousButton={
+				<button type="button">
+					<Icon name="ArrowLeft" fill="red" />
+					Custom Previous
+				</button>
+			}
+		>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+			<Carousel.Item label="Slide 2 of 5">
+				<Image src="/camera.jpeg" alt="A camera with photos in front of it" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 3 of 5">
+				<Image src="/canyon.jpeg" alt="Landscape view of a canyon" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 4 of 5">
+				<Image src="/coffee.jpeg" alt="A cup of coffee" />
+			</Carousel.Item>
+			<Carousel.Item label="Slide 5 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -400,7 +400,7 @@ const Feature = () => (
 ** Show additional custom controls and show full screen toggle **
 
 <Canvas>
-	<Story name="Show additional controls and show full screen toggle">
+	<Story name="Show additional custom controls and show full screen toggle">
 		<Carousel
 			id="carousel-1"
 			label="Carousel of Images"

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -345,4 +345,69 @@ describe("Carousel", () => {
 		const foundLabel = screen.queryByText("1 of 2 super cool images");
 		expect(foundLabel).not.toBeNull();
 	});
+	it("shows additional controls next and previous if opted in", async () => {
+		render(
+			<Carousel id="carousel-2" label="Carousel Label" slidesToShow={1} showAdditionalSlideControls>
+				<Carousel.Item label="Slide 1 of 2">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 2">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		// previous button not visible yet on first render
+		expect(screen.queryAllByText("<")).toHaveLength(0);
+
+		// show next button
+		expect(screen.queryAllByText(">")).toHaveLength(1);
+
+		// click top next button
+		await userEvent.click(screen.getByText(">"));
+
+		await waitFor(() => {
+			// show default previous button
+			expect(screen.queryAllByText("<")).toHaveLength(1);
+
+			// next button no longer visible as it's the last slide
+			expect(screen.queryAllByText(">")).toHaveLength(0);
+		});
+	});
+	it("shows additional controls next and previous if opted in and custom buttons", async () => {
+		render(
+			<Carousel
+				id="carousel-2"
+				label="Carousel Label"
+				slidesToShow={1}
+				showAdditionalSlideControls
+				additionalNextButton={<button type="button">Next Custom</button>}
+				additionalPreviousButton={<button type="button">Previous Custom</button>}
+			>
+				<Carousel.Item label="Slide 1 of 2">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 2">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		// previous button not visible yet on first render
+		expect(screen.queryAllByText("Previous Custom")).toHaveLength(0);
+
+		// show next button
+		expect(screen.queryAllByText("Next Custom")).toHaveLength(1);
+
+		// click top next button
+		await userEvent.click(screen.getByText("Next Custom"));
+
+		await waitFor(() => {
+			// show default previous button
+			expect(screen.queryAllByText("Previous Custom")).toHaveLength(1);
+
+			// next button no longer visible as it's the last slide
+			expect(screen.queryAllByText("Next Custom")).toHaveLength(0);
+		});
+	});
 });

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -370,7 +370,7 @@ describe("Carousel", () => {
 		expect(foundLabel).not.toBeNull();
 	});
 	it("shows additional controls next and previous if opted in", async () => {
-		render(
+		const { container } = render(
 			<Carousel id="carousel-2" label="Carousel Label" slidesToShow={1} showAdditionalSlideControls>
 				<Carousel.Item label="Slide 1 of 2">
 					<div />
@@ -381,21 +381,40 @@ describe("Carousel", () => {
 			</Carousel>
 		);
 
-		// previous button not visible yet on first render
-		expect(screen.queryAllByText("<")).toHaveLength(0);
+		const controlsArea = container.querySelector(".c-carousel__counter-controls-container");
 
 		// show next button
-		expect(screen.queryAllByText(">")).toHaveLength(1);
+		expect(controlsArea.querySelectorAll(".c-carousel__button--additional-next")).toHaveLength(1);
+
+		// show svg within controls area additional next button
+		expect(controlsArea.querySelector(".c-carousel__button--additional-next svg")).not.toBeNull();
+
+		// previous button not visible yet on first render
+		expect(controlsArea.querySelectorAll(".c-carousel__button--additional-previous")).toHaveLength(
+			0
+		);
 
 		// click top next button
-		await userEvent.click(screen.getByText(">"));
+		await userEvent.click(controlsArea.querySelector(".c-carousel__button--additional-next"));
 
 		await waitFor(() => {
-			// show default previous button
-			expect(screen.queryAllByText("<")).toHaveLength(1);
+			const updatedControlsArea = container.querySelector(
+				".c-carousel__counter-controls-container"
+			);
 
 			// next button no longer visible as it's the last slide
-			expect(screen.queryAllByText(">")).toHaveLength(0);
+			expect(
+				updatedControlsArea.querySelectorAll(".c-carousel__button--additional-next")
+			).toHaveLength(0);
+
+			// show default previous button
+			expect(
+				updatedControlsArea.querySelectorAll(".c-carousel__button--additional-previous")
+			).toHaveLength(1);
+			// show svg within controls area additional previous button
+			expect(
+				controlsArea.querySelector(".c-carousel__button--additional-previous svg")
+			).not.toBeNull();
 		});
 	});
 	it("shows additional controls next and previous if opted in and custom buttons", async () => {


### PR DESCRIPTION
## Ticket

- [TMEDIA-838](https://arcpublishing.atlassian.net/browse/TMEDIA-838) sub-task of https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-689&assignee=5e387d6a1b1d910e5dfd7a9b

## Description

Additional image arrows that can be toggled to show and hide via theme file 

## Acceptance Criteria

Image arrows near the image counter drop off at the mobile breakpoint (the large arrows on the image itself stay)

## Test Steps

1. Checkout branch - `git checkout TMEDIA-838-image-arrows-counter`
2. Run Storybook `npm run storybook`
3. See the additional default buttons story. Make sure you're on commerce theme
![Screen Shot 2022-04-19 at 13 43 54](https://user-images.githubusercontent.com/5950956/164073819-55e1dc71-1c37-404d-b841-87ffe7678272.png)
4. Click next ">" arrow and see the other previous "<" show. This can be spaced by the theme file 
![Screen Shot 2022-04-19 at 13 44 55](https://user-images.githubusercontent.com/5950956/164073916-8f4c99b8-477f-4b7f-a2a9-4efb40bf1532.png)
5. Go to the custom additional controls story. 
6. See the various updates to the inline custom buttons
![Screen Shot 2022-04-19 at 13 46 41](https://user-images.githubusercontent.com/5950956/164074234-bc83b688-4c4f-4e76-b246-9846b4cec13e.png)

![Screen Shot 2022-04-19 at 13 46 54](https://user-images.githubusercontent.com/5950956/164074251-c5b24812-f02e-4c7f-b9b2-0cdf8cf27aca.png)
7. In the commerce theme, shrink the screen to mobile. See the additional arrows no longer visible via display: none

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
