### PR TITLE
Heading - Add truncation

### DIFF
--- a/src/components/headings/_index.scss
+++ b/src/components/headings/_index.scss
@@ -8,7 +8,7 @@
 	-webkit-box-orient: vertical;
 	-moz-box-oriented: vertical;
 	/* opera */
-	text-overflow: -o-ellipsis-lastline;
+	text-overflow: ellipsis;
 
 	@include scss.component-properties("heading");
 

--- a/src/components/headings/_index.scss
+++ b/src/components/headings/_index.scss
@@ -7,7 +7,6 @@
 	display: -webkit-box;
 	-webkit-box-orient: vertical;
 	-moz-box-oriented: vertical;
-	/* opera */
 	text-overflow: ellipsis;
 
 	@include scss.component-properties("heading");

--- a/src/components/headings/_index.scss
+++ b/src/components/headings/_index.scss
@@ -1,5 +1,16 @@
 @use "../../scss";
 
 .c-heading {
+	--heading-truncation: var(--c-heading--webkit-line-clamp, "none");
+
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-moz-box-oriented: vertical;
+	/* opera */
+	text-overflow: -o-ellipsis-lastline;
+
 	@include scss.component-properties("heading");
+
+	-webkit-line-clamp: var(--heading-truncation);
 }

--- a/src/components/headings/heading/index.jsx
+++ b/src/components/headings/heading/index.jsx
@@ -3,7 +3,7 @@ import LevelContext from "../context";
 
 const COMPONENT_CLASS_NAME = "c-heading";
 
-const Heading = ({ className, children, ...rest }) => (
+const Heading = ({ className, children, truncationLines, ...rest }) => (
 	<LevelContext.Consumer>
 		{(level) => {
 			// max heading level is 6
@@ -12,6 +12,7 @@ const Heading = ({ className, children, ...rest }) => (
 			return (
 				<HeadingTag
 					{...rest}
+					style={{ "--heading-truncation": truncationLines > 0 ? truncationLines : null }}
 					className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
 				>
 					{children}
@@ -26,6 +27,10 @@ Heading.propTypes = {
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
 	children: PropTypes.node.isRequired,
+	/** Number of lines to show before being truncated and augmented with ellipses.
+	 	Default value is `0` and results in no truncation of content.
+	 */
+	truncationLines: PropTypes.number,
 };
 
 export default Heading;

--- a/src/components/headings/index.stories.mdx
+++ b/src/components/headings/index.stories.mdx
@@ -80,6 +80,19 @@ const SectionBlockFeature = () => (
 	</Story>
 </Canvas>
 
+** Heading with truncation **
+
+<Canvas>
+	<Story name="Heading with truncation">
+		<div style={{ width: "200px" }}>
+			<Heading truncationLines={2}>
+				Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing
+				industries for previewing layouts and visual mockups.
+			</Heading>
+		</div>
+	</Story>
+</Canvas>
+
 ** Nested Headings **
 
 <Canvas>

--- a/src/components/headings/index.test.jsx
+++ b/src/components/headings/index.test.jsx
@@ -22,6 +22,18 @@ describe("Heading", () => {
 		expect(headingOutput).toHaveAttribute("id", "custom-id");
 	});
 
+	it("should not apply truncation by default", () => {
+		const { container } = render(<Heading>Heading Text</Heading>);
+		expect(container.querySelector(".c-heading").getAttribute("style")).toBe(null);
+	});
+
+	it("should apply truncation when specified", () => {
+		const { container } = render(<Heading truncationLines={3}>Heading Text</Heading>);
+		expect(container.querySelector(".c-heading").getAttribute("style")).toContain(
+			"--heading-truncation: 3;"
+		);
+	});
+
 	it("should render additional classes", () => {
 		render(<Heading className="test-class">Hello World</Heading>);
 		const headingOutput = screen.getByRole("heading", {

--- a/src/components/paragraph/_index.scss
+++ b/src/components/paragraph/_index.scss
@@ -7,7 +7,6 @@
 	display: -webkit-box;
 	-webkit-box-orient: vertical;
 	-moz-box-oriented: vertical;
-	/* opera */
 	text-overflow: ellipsis;
 
 	@include scss.component-properties("paragraph");

--- a/src/components/paragraph/_index.scss
+++ b/src/components/paragraph/_index.scss
@@ -8,7 +8,7 @@
 	-webkit-box-orient: vertical;
 	-moz-box-oriented: vertical;
 	/* opera */
-	text-overflow: -o-ellipsis-lastline;
+	text-overflow: ellipsis;
 
 	@include scss.component-properties("paragraph");
 


### PR DESCRIPTION
## Description

Both [TBRANDS-28](https://arcpublishing.atlassian.net/browse/TBRANDS-28) and [TBRANDS-25](https://arcpublishing.atlassian.net/browse/TBRANDS-25) have the requirement to have truncation applied to the Headings and rather than duplicate code and have inconsistent approaches within blocks this should be brought back to the component level to ensure consistency and allow for other blocks and consumers to have the same functionality

## Test Steps

1. Checkout branch - `git checkout heading-add-truncation-prop`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Heading storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
