### PR TITLE
Ensure Children component order is maintained

### DIFF
--- a/src/components/price/index.jsx
+++ b/src/components/price/index.jsx
@@ -6,8 +6,9 @@ import Sale from "./_children/Sale";
 const COMPONENT_CLASS_NAME = "c-price";
 
 const Price = ({ children, className, ...rest }) => {
-	const subComponents = Object.values(Price).map((subcomponentType) =>
-		Children.map(children, (child) => (child?.type === subcomponentType ? child : null))
+	const allowedTypes = Object.values(Price).map((subcomponentType) => subcomponentType);
+	const subComponents = Children.map(children, (child) =>
+		child?.type && allowedTypes?.find((e) => e === child?.type) ? child : null
 	);
 
 	return (

--- a/src/components/price/index.jsx
+++ b/src/components/price/index.jsx
@@ -6,7 +6,9 @@ import Sale from "./_children/Sale";
 const COMPONENT_CLASS_NAME = "c-price";
 
 const Price = ({ children, className, ...rest }) => {
+	// Array of allowed Children component types
 	const allowedTypes = Object.values(Price).map((subcomponentType) => subcomponentType);
+	// Loop over the Children and remove components that are not one of the allowedTypes
 	const subComponents = Children.map(children, (child) =>
 		child?.type && allowedTypes?.find((e) => e === child?.type) ? child : null
 	);

--- a/src/components/price/index.test.jsx
+++ b/src/components/price/index.test.jsx
@@ -1,8 +1,65 @@
 import { render, screen } from "@testing-library/react";
+import renderer from "react-test-renderer";
 
 import Price from ".";
 
 describe("Price", () => {
+	it("should render in order passed in", () => {
+		const tree = renderer
+			.create(
+				<Price>
+					<Price.Sale>$100</Price.Sale>
+					<Price.List>$200</Price.List>
+				</Price>
+			)
+			.toJSON();
+
+		expect(tree).toMatchInlineSnapshot(`
+		<div
+		  className="c-price"
+		  data-testid="price"
+		>
+		  <div
+		    className="c-price__sale"
+		  >
+		    $100
+		  </div>
+		  <div
+		    className="c-price__list"
+		  >
+		    $200
+		  </div>
+		</div>
+	`);
+
+		const treeAlt = renderer
+			.create(
+				<Price>
+					<Price.List>$200</Price.List>
+					<Price.Sale>$100</Price.Sale>
+				</Price>
+			)
+			.toJSON();
+
+		expect(treeAlt).toMatchInlineSnapshot(`
+		<div
+		  className="c-price"
+		  data-testid="price"
+		>
+		  <div
+		    className="c-price__list"
+		  >
+		    $200
+		  </div>
+		  <div
+		    className="c-price__sale"
+		  >
+		    $100
+		  </div>
+		</div>
+	`);
+	});
+
 	it("should render sub components", () => {
 		render(
 			<Price>


### PR DESCRIPTION
## Description

Update the Price Component to ensure the children components that are only allowed to be used are output in the order passed into the component

## Test Steps

* Tests have been updated

1. Checkout branch - `git checkout price-component-maintain-child-order`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Price storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
