### PR TITLE
TBRANDS-35: Update video embed to exclude undefined values from being presented

### DIFF
--- a/src/utils/format-powa-video-embed/index.js
+++ b/src/utils/format-powa-video-embed/index.js
@@ -5,7 +5,9 @@ const formatPowaVideoEmbed = (embedMarkup, powaFields = {}) => {
 		const doc = parser.parseFromString(embedMarkup, "text/html");
 		const embedHTMLWithPlayStatus = doc.body;
 
-		const powaFieldEntries = Object.entries(powaFields);
+		const powaFieldEntries = Object.entries(powaFields).filter(
+			([, value]) => typeof value !== "undefined"
+		);
 
 		// set the rest of powa fields
 		// https://redirector.arcpublishing.com/alc/arc-products/videocenter/user-docs/video-center-player-settings/

--- a/src/utils/format-powa-video-embed/index.test.js
+++ b/src/utils/format-powa-video-embed/index.test.js
@@ -17,3 +17,12 @@ it("returns a powa embed code with fields attached with data-", () => {
 		})
 	).toMatchInlineSnapshot(`"<div class=\\"powa\\" data-powavideoid=\\"12345\\"></div>"`);
 });
+
+it("returns a powa embed code with fields that are defined attached with data-", () => {
+	expect(
+		formatPowaVideoEmbed('<div class="powa" ></div>', {
+			powaVideoId: "12345",
+			bad: undefined,
+		})
+	).toMatchInlineSnapshot(`"<div class=\\"powa\\" data-powavideoid=\\"12345\\"></div>"`);
+});


### PR DESCRIPTION
## Ticket

- [TBRANDS-35](https://arcpublishing.atlassian.net/browse/TBRANDS-35)

## Description

The embed markup for the powa video component is including undefined values.  this will filter out those bad values so they are not improperly output.

## Acceptance Criteria

N/A

## Test Steps

1. Checkout branch - `git checkout tbrands-35`
2. Update dependencies - `npm i`
3. Run Storybook `npm run test`
4. Examine the `util/format-powa-video-embed` tests

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
