### PR TITLE
Adding format-url util from engine-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ import Stack from "./src/components/stack";
 import Video from "./src/components/video";
 import formatCredits from "./src/utils/format-credits";
 import formatPowaVideoEmbed from "./src/utils/format-powa-video-embed";
+import formatURL from "./src/utils/format-url";
 import getImageFromANS from "./src/utils/get-image-from-ans";
 import useInterval from "./src/utils/hooks/use-interval";
 import isServerSide from "./src/utils/is-server-side";
@@ -34,6 +35,7 @@ export {
 	Date,
 	formatCredits,
 	formatPowaVideoEmbed,
+	formatURL,
 	getImageFromANS,
 	Grid,
 	Heading,

--- a/src/utils/format-url/index.js
+++ b/src/utils/format-url/index.js
@@ -1,0 +1,35 @@
+const getLocation = (uri) => {
+	let url;
+
+	if (typeof window === "undefined") {
+		url = new URL(uri, "http://example.com");
+	} else {
+		url = document.createElement("a");
+		// IE doesn't populate all link properties when setting .href with a relative URL,
+		// however .href will return an absolute URL which then can be used on itself
+		// to populate these additional fields.
+		url.href = uri;
+
+		if (url.host === "") {
+			url.href = `${url.href}`;
+		}
+	}
+
+	return url;
+};
+
+const formatURL = (item) => {
+	const url = getLocation(item);
+
+	if (url.hash || url.search || url.pathname.match(/\./)) {
+		return item;
+	}
+
+	if (item[item.length - 1] !== "/") {
+		return `${item}/`;
+	}
+
+	return item;
+};
+
+export default formatURL;

--- a/src/utils/format-url/index.test.js
+++ b/src/utils/format-url/index.test.js
@@ -1,0 +1,36 @@
+import formatURL from "./index";
+
+describe("Format url should add a slash on the end of a link if", () => {
+	it("it is an internal url without an ending slash", () => {
+		const linkWithoutEndingSlash = "/test";
+
+		expect(formatURL(linkWithoutEndingSlash)).toStrictEqual(`${linkWithoutEndingSlash}/`);
+	});
+});
+
+describe("Format url should not add a slash at the end if", () => {
+	it("hash params", () => {
+		const linkWithHashParams = "/test/page#section";
+		expect(formatURL(linkWithHashParams)).toStrictEqual(linkWithHashParams);
+	});
+
+	it("it has extension .html", () => {
+		const linkWithHtmlExtension = "/entertaiment/page.html";
+		expect(formatURL(linkWithHtmlExtension)).toStrictEqual(linkWithHtmlExtension);
+	});
+
+	it("is a mailto link", () => {
+		const mailToLink = "mailto:readers@washpost.com";
+		expect(formatURL(mailToLink)).toStrictEqual(mailToLink);
+	});
+	it("it is with query params", () => {
+		const linkWithQuery = "/test?query=a";
+
+		expect(formatURL(linkWithQuery)).toStrictEqual(linkWithQuery);
+	});
+	it("it already has one", () => {
+		const linkWithSlash = "/test/";
+
+		expect(formatURL(linkWithSlash)).toStrictEqual(linkWithSlash);
+	});
+});


### PR DESCRIPTION
## Ticket

- This is needed in part to fulfill the overline block conversion:  https://arcpublishing.atlassian.net/browse/TMEDIA-735

## Description

Moving the formatURL (https://github.com/WPMedia/engine-theme-sdk/blob/cc82e0bd703f5d669e241e2270b20f77ec905788/src/utils/formatURL.ts) util from engine sdk over to the component util 

