### PR TITLE
Change utils to return non-fragment values

### DIFF
--- a/src/utils/format-authors/index.jsx
+++ b/src/utils/format-authors/index.jsx
@@ -1,20 +1,17 @@
 import Link from "../../components/link";
 import serialJoin from "../serial-join";
 
-const formatAuthors = (byCredits = [], conjunction = "and") => (
-	<>
-		{serialJoin(
-			byCredits
-				.map((credit) => ({
-					type: credit?.type,
-					name: credit?.additional_properties?.original?.byline || credit?.name,
-					url: credit?.url,
-				}))
-				.filter(({ type, name }) => type === "author" && name)
-				.map(({ name, url }) => (url ? <Link href={url}>{name}</Link> : name)),
-			conjunction
-		)}
-	</>
-);
+const formatAuthors = (byCredits = [], conjunction = "and") =>
+	serialJoin(
+		byCredits
+			.map((credit) => ({
+				type: credit?.type,
+				name: credit?.additional_properties?.original?.byline || credit?.name,
+				url: credit?.url,
+			}))
+			.filter(({ type, name }) => type === "author" && name)
+			.map(({ name, url }) => (url ? <Link href={url}>{name}</Link> : name)),
+		conjunction
+	);
 
 export default formatAuthors;

--- a/src/utils/serial-join/index.jsx
+++ b/src/utils/serial-join/index.jsx
@@ -2,27 +2,24 @@ import { Fragment } from "react";
 
 // Join based on rules for serial comma use (aka. Oxford comma)
 
-const serialJoin = (list = [], conjunction = "and", delimiter = ",", spacer = " ") => (
-	<>
-		{list
-			.filter(
-				(item) => typeof item !== "undefined" && item !== null && Object.keys(item).length !== 0
-			)
-			.map((item, index, { length }) => (
-				/* eslint-disable-next-line react/no-array-index-key */
-				<Fragment key={`${item}_${index}`}>
-					{length > 1 && index === length - 1 ? (
-						<>
-							{conjunction}
-							{spacer}
-						</>
-					) : null}
-					{item}
-					{length > 2 && index !== length - 1 ? delimiter : null}
-					{index !== length - 1 ? spacer : null}
-				</Fragment>
-			))}
-	</>
-);
+const serialJoin = (list = [], conjunction = "and", delimiter = ",", spacer = " ") =>
+	list
+		.filter(
+			(item) => typeof item !== "undefined" && item !== null && Object.keys(item).length !== 0
+		)
+		.map((item, index, { length }) => (
+			/* eslint-disable-next-line react/no-array-index-key */
+			<Fragment key={`${item}_${index}`}>
+				{length > 1 && index === length - 1 ? (
+					<>
+						{conjunction}
+						{spacer}
+					</>
+				) : null}
+				{item}
+				{length > 2 && index !== length - 1 ? delimiter : null}
+				{index !== length - 1 ? spacer : null}
+			</Fragment>
+		));
 
 export default serialJoin;


### PR DESCRIPTION
## Ticket

- [TMEDIA-732](https://arcpublishing.atlassian.net/browse/TMEDIA-732)

## Description

This is to fix an issue that was found in QA where the value returned was being interpreted as a strinfg.

## Test Steps

1. Checkout branch - `git checkout tmedia-732`
2. Run Storybook `npm run test`
3. Check out the test for `util/format-authors` and `util/serial-join`

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed relevant documentation has been updated/added.
- [ ] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
