### PR TITLE
Paragraph children not required

### DIFF
--- a/src/components/paragraph/index.jsx
+++ b/src/components/paragraph/index.jsx
@@ -19,7 +19,7 @@ Paragraph.defaultProps = {
 
 Paragraph.propTypes = {
 	/** Elements that will be displayed within the component. */
-	children: PropTypes.any.isRequired,
+	children: PropTypes.any,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** Number of lines to show before being truncated and augmented with ellipses.

--- a/src/components/paragraph/index.stories.mdx
+++ b/src/components/paragraph/index.stories.mdx
@@ -8,6 +8,10 @@ import Paragraph from "./";
 
 Outputs a paragraph of text. Allows for plain text as well as text with HTML markup. Provides for truncation as well.
 
+If the text you are trying to output has HTML entities within it you will not be able to
+use the `{children}`. You will need to use `dangerouslySetInnerHTML` to overcome a
+limitation with JSX
+
 ## Usage
 
 ```jsx


### PR DESCRIPTION
## Ticket

- [TMEDIA-730](https://arcpublishing.atlassian.net/browse/TMEDIA-730)

## Description

There are times when we need to output HTML with HTML entities within it in a paragraph and the limitations of JSX does not output entities with `{children}`. To overcome this you have to use `dangerouslySetInnerHTML`  - in doing so as children is marked as required you get React warnings.

Required as part of the Article Body Block ticket 

## Test Steps

No additional testing needed

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
