### PR TITLE
TMEDIA-893 - Update Button Children Output

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -4,7 +4,7 @@
 	value - which ESLint is unable to parse as acceptable when in the use case below
 	is valid as there is a default and the use of oneOf PropType validation
 */
-import { forwardRef } from "react";
+import { Children, forwardRef } from "react";
 import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-button";
@@ -47,7 +47,7 @@ const Button = forwardRef((props, ref) => {
 	const buttonContents = (
 		<>
 			{iconLeft}
-			<span>{children}</span>
+			{Children.count(children) ? <span>{children}</span> : null}
 			{iconRight}
 		</>
 	);

--- a/src/components/button/index.stories.mdx
+++ b/src/components/button/index.stories.mdx
@@ -149,6 +149,17 @@ When using the `disabled` property any events will need to account for preventin
 	</Story>
 </Preview>
 
+** Left Icon Only **
+
+<Preview>
+	<Story name="Left Icon Only">
+		<Button
+			accessibilityLabel="My Account"
+			iconLeft={<Icon name="User" width="24" height="24" />}
+		/>
+	</Story>
+</Preview>
+
 ** Full Width **
 
 <Preview>

--- a/src/components/button/index.test.jsx
+++ b/src/components/button/index.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import renderer from "react-test-renderer";
 
 import Button from ".";
 
@@ -37,6 +38,21 @@ describe("Button", () => {
 
 		expect(element).toHaveClass(ORIGINAL_CLASSES);
 		expect(element).toHaveClass("c-button--primary");
+	});
+
+	it("should only render children span when children passed", () => {
+		const tree = renderer.create(<Button iconLeft={<p>Icon?</p>} />).toJSON();
+
+		expect(tree).toMatchInlineSnapshot(`
+		<button
+		  className="c-button c-button--medium c-button--default"
+		  type="button"
+		>
+		  <p>
+		    Icon?
+		  </p>
+		</button>
+	`);
 	});
 
 	it("should render as an anchor", () => {


### PR DESCRIPTION
## Ticket

- [TMEDIA-893](https://arcpublishing.atlassian.net/browse/TMEDIA-893)

## Description

Only output `span` when children is passed in

## Test Steps

Storybook and Unit Tests

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
