### PR TITLE
Update Grid to have an as prop for denoting the HTML element to use

### DIFF
--- a/src/components/grid/index.jsx
+++ b/src/components/grid/index.jsx
@@ -2,16 +2,25 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-grid";
 
-const Grid = ({ children, className, ...rest }) => (
-	<div
-		{...rest}
-		className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
-	>
-		{children}
-	</div>
-);
+const Grid = ({ as, children, className, ...rest }) => {
+	const Element = `${as}`;
+	return (
+		<Element
+			{...rest}
+			className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
+		>
+			{children}
+		</Element>
+	);
+};
+
+Grid.defaultProps = {
+	as: "div",
+};
 
 Grid.propTypes = {
+	/** Specify the HTML Element to use to render as */
+	as: PropTypes.string,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */

--- a/src/components/grid/index.stories.mdx
+++ b/src/components/grid/index.stories.mdx
@@ -11,6 +11,17 @@ import Grid from ".";
 The `<Grid>` component is an wrapper to the CSS Grid layout in order for Themes to
 be able to control two-dimensional grid layout's within blocks.
 
+## as
+
+The `Grid` will default to use the HTML `div` element for rendering. There will be times
+where the `Grid` will be used for sectioning and the `div` element does not provide semantic
+meaning, to avoid having to use additional markup to bring back semantics use the `as` prop to
+render the `Grid` as a different HTML element. By using the `as` property you are then required
+to ensure all the correct attributes for a given tag are still passed through.
+
+**Note:** The `as` prop's primary use case if for sectioning. There is likely a component
+better suited for your needs. For example: `Link` component should be used for anchor's.
+
 For more resources on CSS Grid:
 
 - Documentation https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout


### PR DESCRIPTION
## Description

As part of the Small Manual Promo block conversion it was noted that the Grid component could use the `as` prop as per the `Stack` component. This pull request adds the `as` property to the `Grid` component.

https://github.com/WPMedia/arc-themes-blocks/pull/1387

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
