### PR TITLE
TBRANDS 87: Remove hard-coded height from buttons for carousel

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -322,7 +322,11 @@
 					box-shadow: var(--global-box-shadow-1),
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
+					height: var(--global-spacing-8),
 					width: var(--global-spacing-8),
+				),
+				carousel-control-button: (
+					width: auto,
 				),
 				carousel-track: (
 					gap: var(--global-spacing-2),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -323,9 +323,6 @@
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
-				),
-				carousel-control-button: (
 					width: auto,
 				),
 				carousel-track: (

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -324,6 +324,10 @@
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
 					width: auto,
+					padding: 0 var(--global-spacing-2),
+					display: flex,
+					align-items: center,
+					gap: var(--global-spacing-2),
 				),
 				carousel-track: (
 					gap: var(--global-spacing-2),

--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -322,7 +322,6 @@
 					box-shadow: var(--global-box-shadow-1),
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
-					height: var(--global-spacing-8),
 					width: var(--global-spacing-8),
 				),
 				carousel-track: (

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -323,7 +323,6 @@
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
 				),
 				carousel-track: (
 					gap: var(--global-spacing-2),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -323,9 +323,6 @@
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
-					width: var(--global-spacing-8),
-				),
-				carousel-control-button: (
 					width: auto,
 				),
 				carousel-track: (

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -323,6 +323,10 @@
 					border-radius: var(--border-radius),
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
+					width: var(--global-spacing-8),
+				),
+				carousel-control-button: (
+					width: auto,
 				),
 				carousel-track: (
 					gap: var(--global-spacing-2),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -324,6 +324,10 @@
 					background-color: var(--global-white),
 					height: var(--global-spacing-8),
 					width: auto,
+					padding: 0 var(--global-spacing-2),
+					display: flex,
+					align-items: center,
+					gap: var(--global-spacing-2),
 				),
 				carousel-track: (
 					gap: var(--global-spacing-2),

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -45,7 +45,7 @@
 		flex: 0 0
 			calc(
 				var(--slide-width) -
-					calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
+				calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
 			);
 
 		@include scss.component-properties("carousel-slide");

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -44,8 +44,8 @@
 	&__slide {
 		flex: 0 0
 			calc(
-				var(--slide-width) -calc(var(--slide-gap) * calc(var(--viewable-slides) - 1)
-							var(--viewable-slides))
+				var(--slide-width) -
+					calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
 			);
 
 		@include scss.component-properties("carousel-slide");

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -44,8 +44,8 @@
 	&__slide {
 		flex: 0 0
 			calc(
-				var(--slide-width) -
-					calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
+				var(--slide-width) -calc(var(--slide-gap) * calc(var(--viewable-slides) - 1)
+							var(--viewable-slides))
 			);
 
 		@include scss.component-properties("carousel-slide");

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -45,7 +45,7 @@
 		flex: 0 0
 			calc(
 				var(--slide-width) -
-				calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
+					calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
 			);
 
 		@include scss.component-properties("carousel-slide");
@@ -68,10 +68,6 @@
 		justify-content: space-between;
 		place-self: start;
 		width: 100%;
-
-		button {
-			@include scss.component-properties("carousel-control-button");
-		}
 
 		@include scss.component-properties("carousel-controls");
 	}

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -45,7 +45,7 @@
 		flex: 0 0
 			calc(
 				var(--slide-width) -
-				calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
+					calc(var(--slide-gap) * calc(var(--viewable-slides) - 1) / var(--viewable-slides))
 			);
 
 		@include scss.component-properties("carousel-slide");
@@ -68,6 +68,10 @@
 		justify-content: space-between;
 		place-self: start;
 		width: 100%;
+
+		button {
+			@include scss.component-properties("carousel-control-button");
+		}
 
 		@include scss.component-properties("carousel-controls");
 	}


### PR DESCRIPTION
## Ticket

- [TBRANDS-87](https://arcpublishing.atlassian.net/browse/TBRANDS-87)

## Description

Remove hard-coded height so text can grow horizontally 

## Acceptance Criteria

Text is no longer cutoff in button 

## Test Steps

Compare stories in chromatic to show the text no longer cutoff

## Deps 
- Will make feature pack updates to news and brands based on this 

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
