### PR TITLE
TMEDIA-852 Image component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
 	plugins: ["react", "jest", "jsx-a11y", "react-hooks", "sort-exports"],
 	rules: {
 		"global-require": "off",
-		indent: ["error", "tab"],
 		"no-tabs": [
 			"error",
 			{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,8 +27,6 @@ module.exports = {
 				allowIndentationTabs: true,
 			},
 		],
-		"react/jsx-indent": [2, "tab"],
-		"react/jsx-indent-props": [2, "tab"],
 		"no-underscore-dangle": [
 			"error",
 			{

--- a/src/components/image/_index.scss
+++ b/src/components/image/_index.scss
@@ -3,6 +3,11 @@
 .c-image {
 	color: rgb(255 0 0);
 	font-style: italic;
+	// don't want the image to grow larger than itself
+	// without it, we couldn't use height and width for reserving space and srcset and sizes
+	inline-size: max-content;
+	// don't want the image to shrink smaller than its intrinsic size due to height and width set
+	block-size: auto;
 
 	@include scss.component-properties("image");
 }

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -22,15 +22,8 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, respo
 		);
 	}
 
-	let aspectRatio = 0;
-
-	if (height && width) {
-		aspectRatio = width / height;
-	}
-
 	// add all options except height and width
 	const stringOptionsWithoutHeightWidth = Object.keys(resizedOptions).reduce((acc, key) => {
-		// skip height and width setting to account for different sizes
 		if (key === "height" || key === "width") {
 			return acc;
 		}
@@ -45,34 +38,30 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, respo
 	// "https://resizer.com" + "\image.jpg" + "?auth=secret&filter=true"
 	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(src, stringOptionsWithoutHeightWidth);
 
-	let responsiveHeightsAndWidths = [];
-	if (aspectRatio === 0) {
-		responsiveHeightsAndWidths = responsiveImages.reduce((accumulator, responsiveImageWidth) => {
-			if (Number.isInteger(responsiveImageWidth) && responsiveImageWidth > 0) {
-				return [
-					...accumulator,
-					{
-						width: responsiveImageWidth,
-					},
-				];
-			}
-			return accumulator;
-		}, []);
-	} else {
-		// divide the derived aspect ratio by each of the responsiveImages widths to get the height
-		responsiveHeightsAndWidths = responsiveImages.reduce((accumulator, responsiveImageWidth) => {
-			if (Number.isInteger(responsiveImageWidth) && responsiveImageWidth > 0) {
-				return [
-					...accumulator,
-					{
-						width: responsiveImageWidth,
-						height: responsiveImageWidth / aspectRatio,
-					},
-				];
-			}
-			return accumulator;
-		}, []);
+	let aspectRatio = 0;
+
+	// if no height and width, no responsive image calculation
+	if (height && width) {
+		aspectRatio = width / height;
 	}
+
+	const responsiveHeightsAndWidths = responsiveImages.reduce(
+		(accumulator, responsiveImageWidth) => {
+			if (Number.isInteger(responsiveImageWidth) && responsiveImageWidth > 0) {
+				return [
+					...accumulator,
+					{
+						width: responsiveImageWidth,
+						// divide the derived aspect ratio by each of the responsiveImages widths to get the height
+						// aspect ratio of zero will not show the height
+						...(aspectRatio !== 0 && { height: responsiveImageWidth / aspectRatio }),
+					},
+				];
+			}
+			return accumulator;
+		},
+		[]
+	);
 
 	// add the height and width to the default src if they exist
 	// auth token will at least exist here so don't need to worry about ? prepend

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -74,6 +74,29 @@ const Image = ({
 		`${width ? `&width=${width}` : ""}${height ? `&height=${height}` : ""}`
 	);
 
+	const responsiveSrcSet =
+		responsiveHeightsAndWidths
+			.map(
+				(responsiveImage) =>
+					`${srcWithOptionsWithoutHeightWidth}&width=${responsiveImage.width}${
+						responsiveImage?.height ? `&height=${responsiveImage.height}` : ""
+					} ${responsiveImage.width}w`
+			)
+			.join(", ") || null;
+
+	const responsiveSizes = sizes
+		? sizes
+				.reduce((sizesStringList, currentSizeObject) => {
+					if (currentSizeObject.isDefault) {
+						return sizesStringList;
+					}
+					return `${sizesStringList}${currentSizeObject.mediaCondition} ${currentSizeObject.sourceSizeValue}, `;
+				}, "")
+				.concat(
+					sizes.find((currentSizeObject) => currentSizeObject.isDefault)?.sourceSizeValue || ""
+				)
+		: null;
+
 	return (
 		<img
 			alt={alt}
@@ -82,31 +105,8 @@ const Image = ({
 			loading={loading}
 			src={defaultSrc}
 			width={width}
-			srcSet={
-				responsiveHeightsAndWidths
-					.map(
-						(responsiveImage) =>
-							`${srcWithOptionsWithoutHeightWidth}&width=${responsiveImage.width}${
-								responsiveImage?.height ? `&height=${responsiveImage.height}` : ""
-							} ${responsiveImage.width}w`
-					)
-					.join(", ") || null
-			}
-			sizes={
-				sizes
-					? sizes
-							.reduce((sizesStringList, currentSizeObject) => {
-								if (currentSizeObject.isDefault) {
-									return sizesStringList;
-								}
-								return `${sizesStringList}${currentSizeObject.mediaCondition} ${currentSizeObject.sourceSizeValue}, `;
-							}, "")
-							.concat(
-								sizes.find((currentSizeObject) => currentSizeObject.isDefault)?.sourceSizeValue ||
-									""
-							)
-					: null
-			}
+			srcSet={responsiveSrcSet}
+			sizes={responsiveSizes}
 		/>
 	);
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -2,7 +2,16 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-image";
 
-const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, responsiveImages }) => {
+const Image = ({
+	alt,
+	className,
+	loading,
+	src,
+	resizedOptions,
+	resizerURL,
+	responsiveImages,
+	sizes,
+}) => {
 	// get the default height and width of the image
 	// use aspect ratio to generate other sizes
 	const { width, height, auth } = resizedOptions;
@@ -89,6 +98,20 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, respo
 							.join(", ")
 					: null
 			}
+			sizes={
+				sizes
+					? sizes
+							.reduce((sizesStringList, currentSizeObject) => {
+								if (currentSizeObject.isDefault) {
+									return sizesStringList;
+								}
+								return `${sizesStringList}${currentSizeObject.mediaCondition} ${currentSizeObject.sourceSizeValue}, `;
+							}, "")
+							.concat(
+								sizes.find((currentSizeObject) => currentSizeObject.isDefault).sourceSizeValue
+							)
+					: null
+			}
 		/>
 	);
 };
@@ -99,6 +122,7 @@ Image.defaultProps = {
 	resizedOptions: {},
 	resizerURL: "",
 	responsiveImages: [],
+	sizes: "",
 };
 
 Image.propTypes = {
@@ -119,6 +143,17 @@ Image.propTypes = {
 	resizerURL: PropTypes.string,
 	/** Array of widths to use as sizes for the image */
 	responsiveImages: PropTypes.arrayOf(PropTypes.number),
+	/** The options relating to each of the available srcset options of the image */
+	sizes: PropTypes.arrayOf(
+		PropTypes.shape({
+			/** Whether it's the default last size available */
+			isDefault: PropTypes.bool,
+			/** The intrinsic width of the image in pixels or responsive units */
+			sourceSizeValue: PropTypes.string,
+			/** Media condition to render the corresponding source size value */
+			mediaCondition: PropTypes.string,
+		})
+	),
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -4,13 +4,21 @@ const COMPONENT_CLASS_NAME = "c-image";
 
 const Image = ({ alt, className, loading, src, resizedOptions }) => {
 	const { width, height } = resizedOptions;
+	const stringOptions = Object.keys(resizedOptions).reduce((acc, key, currentIndex) => {
+		// on the first iteration need to prepend the ? to the string
+		if (currentIndex === 0) {
+			return `?${key}=${resizedOptions[key]}`;
+		}
+		return `${acc}&${key}=${resizedOptions[key]}`;
+	}, "");
+	const srcWithOptions = src.concat(stringOptions);
 	return (
 		<img
 			alt={alt}
 			className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
 			height={height}
 			loading={loading}
-			src={src}
+			src={srcWithOptions}
 			width={width}
 		/>
 	);
@@ -27,14 +35,15 @@ Image.propTypes = {
 	alt: PropTypes.string,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
+	/** Indication of how the browser should load the image, using the native loading attribute of an <img /> tag */
+	loading: PropTypes.oneOf(["lazy", "eager"]),
+	/** Options to pass into v2 resizer, with height and width being used for img tag as well */
 	resizedOptions: PropTypes.shape({
 		/** The intrinsic width of the image in pixels */
 		width: PropTypes.number,
 		/** The intrinsic height of the image in pixels */
 		height: PropTypes.number,
 	}),
-	/** Indication of how the browser should load the image, using the native loading attribute of an <img /> tag */
-	loading: PropTypes.oneOf(["lazy", "eager"]),
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -10,11 +10,13 @@ const Image = ({
 	resizedOptions,
 	resizerURL,
 	responsiveImages,
+	width,
+	height,
 	sizes,
 }) => {
 	// get the default height and width of the image
 	// use aspect ratio to generate other sizes
-	const { width, height, auth } = resizedOptions;
+	const { auth } = resizedOptions;
 
 	if (!auth) {
 		// eslint-disable-next-line no-console
@@ -31,21 +33,15 @@ const Image = ({
 		);
 	}
 
-	// add all options except height and width
-	const stringOptionsWithoutHeightWidth = Object.keys(resizedOptions).reduce((acc, key) => {
-		if (key === "height" || key === "width") {
-			return acc;
-		}
-
-		if (acc === "") {
-			return `?${key}=${resizedOptions[key]}`;
-		}
-
-		return `${acc}&${key}=${resizedOptions[key]}`;
-	}, "");
+	// ex: 'filter=filterHere&auth=abc123'
+	const stringOptionsWithoutHeightWidth = new URLSearchParams(resizedOptions).toString();
 
 	// "https://resizer.com" + "\image.jpg" + "?auth=secret&filter=true"
-	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(src, stringOptionsWithoutHeightWidth);
+	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(
+		src,
+		"?",
+		stringOptionsWithoutHeightWidth
+	);
 
 	let aspectRatio = 0;
 
@@ -124,6 +120,8 @@ Image.defaultProps = {
 	resizerURL: "",
 	responsiveImages: [],
 	sizes: "",
+	width: null,
+	height: null,
 };
 
 Image.propTypes = {
@@ -131,15 +129,12 @@ Image.propTypes = {
 	alt: PropTypes.string,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
+	/** The intrinsic height of the image in pixels */
+	height: PropTypes.number,
 	/** Indication of how the browser should load the image, using the native loading attribute of an <img /> tag */
 	loading: PropTypes.oneOf(["lazy", "eager"]),
 	/** Options to pass into v2 resizer, with height and width being used for img tag as well */
-	resizedOptions: PropTypes.shape({
-		/** The intrinsic width of the image in pixels */
-		width: PropTypes.number,
-		/** The intrinsic height of the image in pixels */
-		height: PropTypes.number,
-	}),
+	resizedOptions: PropTypes.shape({}),
 	/** The URL of the resizer service */
 	resizerURL: PropTypes.string,
 	/** Array of widths to use as sizes for the image */
@@ -155,6 +150,8 @@ Image.propTypes = {
 			mediaCondition: PropTypes.string,
 		})
 	),
+	/** The intrinsic width of the image in pixels */
+	width: PropTypes.number,
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -36,7 +36,7 @@ const Image = ({
 	// ex: 'filter=filterHere&auth=abc123'
 	const stringOptionsWithoutHeightWidth = new URLSearchParams(resizedOptions).toString();
 
-	// "https://resizer.com" + "\image.jpg" + "?auth=secret&filter=true"
+	// "https://resizer.com/" + "image.jpg" + "?auth=secret&filter=true"
 	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(
 		src,
 		"?",
@@ -133,7 +133,7 @@ Image.propTypes = {
 	loading: PropTypes.oneOf(["lazy", "eager"]),
 	/** Options to pass into v2 resizer, with height and width being used for img tag as well */
 	resizedOptions: PropTypes.shape({}),
-	/** The URL of the resizer service */
+	/** The URL of the resizer service. Should have a trailing slash */
 	resizerURL: PropTypes.string,
 	/** Array of widths to use as sizes for the image */
 	responsiveImages: PropTypes.arrayOf(PropTypes.number),
@@ -150,7 +150,7 @@ Image.propTypes = {
 	),
 	/** The intrinsic width of the image in pixels */
 	width: PropTypes.number,
-	/** The URL to an image to load and display */
+	/** The URL to an image to load and display. Should not have a leading slash */
 	src: PropTypes.string.isRequired,
 };
 

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -2,8 +2,10 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-image";
 
-const Image = ({ alt, className, loading, src, resizedOptions, resizerURL }) => {
+const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, responsiveImages }) => {
 	const { width, height } = resizedOptions;
+
+	// todo: deduplicate logic with height and width
 	const stringOptions = Object.keys(resizedOptions).reduce((acc, key, currentIndex) => {
 		// on the first iteration need to prepend the ? to the string
 		if (currentIndex === 0) {
@@ -11,7 +13,36 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL }) => 
 		}
 		return `${acc}&${key}=${resizedOptions[key]}`;
 	}, "");
+	// todo: will need to ignore height and width setting here
+	// this will allow the options to be added in the srcset
+	const stringOptionsWithoutHeightWidth = Object.keys(resizedOptions).reduce(
+		(acc, key, currentIndex) => {
+			if (key === "height" || key === "width") {
+				return acc;
+			}
+			// on the first iteration need to prepend the ? to the string
+			if (currentIndex === 0) {
+				return `?${key}=${resizedOptions[key]}`;
+			}
+			return `${acc}&${key}=${resizedOptions[key]}`;
+		},
+		""
+	);
 	const srcWithOptions = resizerURL.concat(src, stringOptions);
+	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(src, stringOptionsWithoutHeightWidth);
+
+	// todo: handle if there's no height and/or no width in the resized options
+	// get the aspect ratio of the image based on the resizedOptions.width and height
+	// height is 100px and width is 200px
+	// aspect ratio is 2
+	const aspectRatio = resizedOptions.width / resizedOptions.height;
+
+	// divide the derived aspect ratio by each of the responsiveImages widths to get the height
+	const responsiveHeightsAndWidths = responsiveImages.map((responsiveImageWidth) => ({
+		width: responsiveImageWidth,
+		height: responsiveImageWidth / aspectRatio,
+	}));
+
 	return (
 		<img
 			alt={alt}
@@ -20,6 +51,13 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL }) => 
 			loading={loading}
 			src={srcWithOptions}
 			width={width}
+			// todo: handle if no responsive images are provided
+			srcSet={responsiveHeightsAndWidths
+				.map(
+					(responsiveImage) =>
+						`${srcWithOptionsWithoutHeightWidth}&width=${responsiveImage.width}&height=${responsiveImage.height} ${responsiveImage.width}w`
+				)
+				.join(", ")}
 		/>
 	);
 };
@@ -29,6 +67,7 @@ Image.defaultProps = {
 	loading: "lazy",
 	resizedOptions: {},
 	resizerURL: "",
+	responsiveImages: [],
 };
 
 Image.propTypes = {
@@ -47,6 +86,8 @@ Image.propTypes = {
 	}),
 	/** The URL of the resizer service */
 	resizerURL: PropTypes.string,
+	/** Array of widths to use as sizes for the image */
+	responsiveImages: PropTypes.arrayOf(PropTypes.number),
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-image";
 
-const Image = ({ alt, className, loading, src, resizedOptions }) => {
+const Image = ({ alt, className, loading, src, resizedOptions, resizerURL }) => {
 	const { width, height } = resizedOptions;
 	const stringOptions = Object.keys(resizedOptions).reduce((acc, key, currentIndex) => {
 		// on the first iteration need to prepend the ? to the string
@@ -11,7 +11,7 @@ const Image = ({ alt, className, loading, src, resizedOptions }) => {
 		}
 		return `${acc}&${key}=${resizedOptions[key]}`;
 	}, "");
-	const srcWithOptions = src.concat(stringOptions);
+	const srcWithOptions = resizerURL.concat(src, stringOptions);
 	return (
 		<img
 			alt={alt}
@@ -28,6 +28,7 @@ Image.defaultProps = {
 	alt: "",
 	loading: "lazy",
 	resizedOptions: {},
+	resizerURL: "",
 };
 
 Image.propTypes = {
@@ -44,6 +45,8 @@ Image.propTypes = {
 		/** The intrinsic height of the image in pixels */
 		height: PropTypes.number,
 	}),
+	/** The URL of the resizer service */
+	resizerURL: PropTypes.string,
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -83,16 +83,14 @@ const Image = ({
 			src={defaultSrc}
 			width={width}
 			srcSet={
-				responsiveHeightsAndWidths.length > 0
-					? responsiveHeightsAndWidths
-							.map(
-								(responsiveImage) =>
-									`${srcWithOptionsWithoutHeightWidth}&width=${responsiveImage.width}${
-										responsiveImage?.height ? `&height=${responsiveImage.height}` : ""
-									} ${responsiveImage.width}w`
-							)
-							.join(", ")
-					: null
+				responsiveHeightsAndWidths
+					.map(
+						(responsiveImage) =>
+							`${srcWithOptionsWithoutHeightWidth}&width=${responsiveImage.width}${
+								responsiveImage?.height ? `&height=${responsiveImage.height}` : ""
+							} ${responsiveImage.width}w`
+					)
+					.join(", ") || null
 			}
 			sizes={
 				sizes

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -108,7 +108,8 @@ const Image = ({
 								return `${sizesStringList}${currentSizeObject.mediaCondition} ${currentSizeObject.sourceSizeValue}, `;
 							}, "")
 							.concat(
-								sizes.find((currentSizeObject) => currentSizeObject.isDefault).sourceSizeValue
+								sizes.find((currentSizeObject) => currentSizeObject.isDefault)?.sourceSizeValue ||
+									""
 							)
 					: null
 			}

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -2,20 +2,24 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-image";
 
-const Image = ({ alt, className, height, loading, src, width }) => (
-	<img
-		alt={alt}
-		className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
-		height={height}
-		loading={loading}
-		src={src}
-		width={width}
-	/>
-);
+const Image = ({ alt, className, loading, src, resizedOptions }) => {
+	const { width, height } = resizedOptions;
+	return (
+		<img
+			alt={alt}
+			className={className ? `${COMPONENT_CLASS_NAME} ${className}` : `${COMPONENT_CLASS_NAME}`}
+			height={height}
+			loading={loading}
+			src={src}
+			width={width}
+		/>
+	);
+};
 
 Image.defaultProps = {
 	alt: "",
 	loading: "lazy",
+	resizedOptions: {},
 };
 
 Image.propTypes = {
@@ -23,14 +27,16 @@ Image.propTypes = {
 	alt: PropTypes.string,
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
-	/** The intrinsic height of the image in pixels */
-	height: PropTypes.number,
+	resizedOptions: PropTypes.shape({
+		/** The intrinsic width of the image in pixels */
+		width: PropTypes.number,
+		/** The intrinsic height of the image in pixels */
+		height: PropTypes.number,
+	}),
 	/** Indication of how the browser should load the image, using the native loading attribute of an <img /> tag */
 	loading: PropTypes.oneOf(["lazy", "eager"]),
 	/** The URL to an image to load and display */
 	src: PropTypes.string.isRequired,
-	/** The intrinsic width of the image in pixels */
-	width: PropTypes.number,
 };
 
 export default Image;

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -8,6 +8,7 @@ const Image = ({ alt, className, loading, src, resizedOptions, resizerURL, respo
 	const { width, height, auth } = resizedOptions;
 
 	if (!auth) {
+		// eslint-disable-next-line no-console
 		console.error("No auth token provided for resizer");
 
 		return (

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -202,10 +202,10 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 	</Story>
 </Canvas>
 
-** Responsive image with viewport width sizes **
+** Responsive image with viewport width sizes, filling about half the screen with vw on desktop **
 
 <Canvas>
-	<Story name="Responsive image with viewport width sizes">
+	<Story name="Responsive image with viewport width sizes, filling about half the screen with vw on desktop">
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -67,8 +67,8 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			width={300}
 			resizedOptions={{
-				width: 300,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
@@ -83,8 +83,8 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
 			resizedOptions={{
-				height: 300,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
@@ -99,9 +99,9 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
+			width={300}
 			resizedOptions={{
-				width: 300,
-				height: 300,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
@@ -116,9 +116,9 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
+			width={300}
 			resizedOptions={{
-				width: 300,
-				height: 300,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
@@ -141,9 +141,9 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
+			width={300}
 			resizedOptions={{
-				width: 300,
-				height: 300,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
@@ -183,9 +183,9 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
+			width={300}
 			resizedOptions={{
-				width: 300,
-				height: 300,
 				quality: 10,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
@@ -209,9 +209,9 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
+			height={300}
+			width={300}
 			resizedOptions={{
-				width: 300,
-				height: 300,
 				quality: 10,
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -202,6 +202,32 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 	</Story>
 </Canvas>
 
+** Responsive image with viewport width sizes **
+
+<Canvas>
+	<Story name="Responsive image with viewport width sizes">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				height: 300,
+				quality: 10,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			responsiveImages={[100, 200, 1000, 1500]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			sizes={[
+				{ isDefault: true, sourceSizeValue: "25vw" },
+				{
+					mediaCondition: "(min-width: 500px)",
+					sourceSizeValue: "40vw",
+				},
+			]}
+		/>
+	</Story>
+</Canvas>
+
 ** Without auth token renders src raw **
 
 <Canvas>

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -16,6 +16,12 @@ For responsive images, the goal is to provide options given the media conditions
 
 Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `resizedOptions` and the `responsiveImages` prop. The `resizedOptions` will also provide the aspect ratio, with `resizedOptions.height` and `resizedOptions.width`, needed to make the `srcset` available images.
 
+The width and height prop are used to set the aspect ratio of the responsive images. For instance, if you set the width of 200 and height of 100, you're using an aspect ratio of 2. Then, if you're using `responsiveImages` of `[100, 200, 300]`, you'll get the height and width of the following: width=100, height=50 for 100, width=200 height=100 for 200, and width=300 height=150 for 300. In this way, the images are responsive based off of width. You are also opting into browser best practices of setting any width to give the browser a hint of how big the image will be. However, the image that's set based off of the `sizes` `mediaCondition` and `sourceSizeValue` will determine how big the image actually will be.
+
+If you don't set a `responsiveImages` array, you will have no responsive image options. However, you will have an image resized exactly like your width and height set.
+
+For more information on responsive image best practices, please see: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images. We are using sizes and srcset based off of these practices, using arc resizer v2 auth and filters. If you seek more customization, you can create your own image component as well. Or, please refer to the Picture component if you require different image art direction or image.
+
 ## Usage
 
 ```jsx

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -9,6 +9,8 @@ import Image from ".";
 Image provide a vital part of story telling for websites. Images are used to complement text, or provide supporting information.
 Images can be used as informational or for decoration. This component will provide the means to display images in a variety of different ways.
 
+For `resizedOptions`, here are the query parameters that are available: https://github.com/WPMedia/arc-photo-resizer/tree/main/docs/usage#query-parameters
+
 ## Usage
 
 ```jsx

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -46,8 +46,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		<Image
 			src="/computer-user.jpeg"
 			alt="A person sat down using a laptop computer"
-			width="200"
-			height="147"
+			resizedOptions={{ width: 200, height: 147 }}
 		/>
 	</Story>
 </Canvas>
@@ -56,7 +55,11 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 
 <Canvas>
 	<Story name="Width only">
-		<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" width="250" />
+		<Image
+			src="/computer-user.jpeg"
+			alt="A person sat down using a laptop computer"
+			resizedOptions={{ width: 250 }}
+		/>
 	</Story>
 </Canvas>
 
@@ -64,6 +67,10 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 
 <Canvas>
 	<Story name="Height only">
-		<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" height="250" />
+		<Image
+			src="/computer-user.jpeg"
+			alt="A person sat down using a laptop computer"
+			resizedOptions={{ height: 250 }}
+		/>
 	</Story>
 </Canvas>

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -6,10 +6,15 @@ import Image from ".";
 
 # Image
 
-Image provide a vital part of story telling for websites. Images are used to complement text, or provide supporting information.
-Images can be used as informational or for decoration. This component will provide the means to display images in a variety of different ways.
+Image provide a vital part of story telling for websites. Images are used to complement text, or provide supporting information. Images can be used as informational or for decoration. This component will provide the means to display images in a variety of different ways.
 
 For `resizedOptions`, here are the query parameters that are available: https://github.com/WPMedia/arc-photo-resizer/tree/main/docs/usage#query-parameters
+
+Crucially, an "auth" key will allow the image to be resized. This object will resize the image to the specified dimensions and other properties given in the query parameters in the `src`.
+
+For responsive images, the goal is to provide options given the media conditions, like screen size, provided using the "sizes" prop that takes in an array of objects. This is will render the [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) string.
+
+Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `resizedOptions` and the `responsiveImages` prop. The `resizedOptions` will also provide the aspect ratio, with `resizedOptions.height` and `resizedOptions.width`, needed to make the `srcset` available images.
 
 ## Usage
 
@@ -29,7 +34,14 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 
 <Canvas>
 	<Story name="Default">
-		<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+		/>
 	</Story>
 </Canvas>
 
@@ -37,50 +49,21 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 
 <Canvas>
 	<Story name="Image not found">
-		<Image src="cat.jpg" alt="A cat jumping up to a ball" />
-	</Story>
-</Canvas>
-
-** Width and Height **
-
-<Canvas>
-	<Story name="Width and Height">
 		<Image
-			src="/computer-user.jpeg"
-			alt="A person sat down using a laptop computer"
-			resizedOptions={{ width: 200, height: 147 }}
+			src="/nowhere.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
 		/>
 	</Story>
 </Canvas>
 
-** Width only **
+** Only width **
 
 <Canvas>
-	<Story name="Width only">
-		<Image
-			src="/computer-user.jpeg"
-			alt="A person sat down using a laptop computer"
-			resizedOptions={{ width: 250 }}
-		/>
-	</Story>
-</Canvas>
-
-** Height only **
-
-<Canvas>
-	<Story name="Height only">
-		<Image
-			src="/computer-user.jpeg"
-			alt="A person sat down using a laptop computer"
-			resizedOptions={{ height: 250 }}
-		/>
-	</Story>
-</Canvas>
-
-** With auth token **
-
-<Canvas>
-	<Story name="With auth token">
+	<Story name="Only width">
 		<Image
 			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
@@ -90,5 +73,139 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 			}}
 			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
 		/>
+	</Story>
+</Canvas>
+
+** Only height **
+
+<Canvas>
+	<Story name="Only height">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				height: 300,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+		/>
+	</Story>
+</Canvas>
+
+** Width and height **
+
+<Canvas>
+	<Story name="Width and height">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				height: 300,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+		/>
+	</Story>
+</Canvas>
+
+** Width and height and many responsive images **
+
+<Canvas>
+	<Story name="Width and height and many responsive images">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				height: 300,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			responsiveImages={[100, 200, 1000]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			sizes={[
+				{ isDefault: true, sourceSizeValue: "1000px" },
+				{
+					mediaCondition: "(min-width: 1000px)",
+					sourceSizeValue: "200px",
+				},
+			]}
+		/>
+	</Story>
+</Canvas>
+
+** Width and height and many responsive images without sizes default **
+
+<Canvas>
+	<Story name="Width and height and many responsive images without sizes default">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				height: 300,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			responsiveImages={[100, 200, 1000]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			sizes={[{ mediaCondition: "(min-width: 1000px)", sourceSizeValue: "200px" }]}
+		/>
+	</Story>
+</Canvas>
+
+** Responsive images without height and width **
+
+<Canvas>
+	<Story name="Responsive images without height and width">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			responsiveImages={[100, 200, 1000]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			sizes={[
+				{ isDefault: true, sourceSizeValue: "1000px" },
+				{
+					mediaCondition: "(min-width: 1000px)",
+					sourceSizeValue: "200px",
+				},
+			]}
+		/>
+	</Story>
+</Canvas>
+
+** Responsive image with in resized options like lowered quality **
+
+<Canvas>
+	<Story name="Responsive image with resized options like lowered quality">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				height: 300,
+				quality: 10,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			responsiveImages={[100, 200, 1000]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			sizes={[
+				{ isDefault: true, sourceSizeValue: "1000px" },
+				{
+					mediaCondition: "(min-width: 1000px)",
+					sourceSizeValue: "200px",
+				},
+			]}
+		/>
+	</Story>
+</Canvas>
+
+** Without auth token renders src raw **
+
+<Canvas>
+	<Story name="Without auth token renders src raw">
+		<Image src="/computer-user.jpeg" alt="A person using a computer" />
 	</Story>
 </Canvas>

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -76,3 +76,19 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 		/>
 	</Story>
 </Canvas>
+
+** With auth token **
+
+<Canvas>
+	<Story name="With auth token">
+		<Image
+			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			resizedOptions={{
+				width: 300,
+				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
+			}}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+		/>
+	</Story>
+</Canvas>

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -27,7 +27,23 @@ For more information on responsive image best practices, please see: https://dev
 ```jsx
 import { Image } from "@wpmedia/arc-themes-components";
 
-const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
+const Feature = () => (
+	<Image
+		src="cat.jpg"
+		width={100}
+		height={100}
+		resizerURL="https://resizer.com/v2/"
+		alt="A cat meowing"
+		resizedOptions={{
+			auth: "secret",
+		}}
+		responsiveImages={[100, 500, 1000]}
+		sizes={[
+			{ isDefault: true, sourceSizeValue: "100px" },
+			{ sourceSizeValue: "500px", mediaCondition: "(min-width: 1000px)" },
+		]}
+	/>
+);
 ```
 
 ## Properties
@@ -41,12 +57,12 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Default">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 		/>
 	</Story>
 </Canvas>
@@ -56,12 +72,12 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Image not found">
 		<Image
-			src="/nowhere.jpg"
+			src="nowhere.jpg"
 			alt="A person posing"
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 		/>
 	</Story>
 </Canvas>
@@ -71,13 +87,13 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Only width">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			width={300}
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 		/>
 	</Story>
 </Canvas>
@@ -87,13 +103,13 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Only height">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 		/>
 	</Story>
 </Canvas>
@@ -103,14 +119,14 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Width and height">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			width={300}
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 		/>
 	</Story>
 </Canvas>
@@ -120,7 +136,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Width and height and many responsive images">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			width={300}
@@ -128,7 +144,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 			sizes={[
 				{ isDefault: true, sourceSizeValue: "1000px" },
 				{
@@ -145,7 +161,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Width and height and many responsive images without sizes default">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			width={300}
@@ -153,7 +169,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 			sizes={[{ mediaCondition: "(min-width: 1000px)", sourceSizeValue: "200px" }]}
 		/>
 	</Story>
@@ -164,13 +180,13 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Responsive images without height and width">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			resizedOptions={{
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 			sizes={[
 				{ isDefault: true, sourceSizeValue: "1000px" },
 				{
@@ -187,7 +203,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Responsive image with resized options like lowered quality">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			width={300}
@@ -196,7 +212,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000]}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 			sizes={[
 				{ isDefault: true, sourceSizeValue: "1000px" },
 				{
@@ -213,7 +229,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 <Canvas>
 	<Story name="Responsive image with viewport width sizes, filling about half the screen with vw on desktop">
 		<Image
-			src="/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			src="HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
 			alt="A person posing"
 			height={300}
 			width={300}
@@ -222,7 +238,7 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 				auth: "ab9e85e4ddf84da579c217bc66331a71941bd99dcfbc17ef0f25b166a094bec4",
 			}}
 			responsiveImages={[100, 200, 1000, 1500]}
-			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2"
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
 			sizes={[
 				{ isDefault: true, sourceSizeValue: "25vw" },
 				{
@@ -238,6 +254,25 @@ const Feature = () => <Image src="cat.jpg" alt="A cat jumping up to a ball" />;
 
 <Canvas>
 	<Story name="Without auth token renders src raw">
-		<Image src="/computer-user.jpeg" alt="A person using a computer" />
+		<Image src="computer-user.jpeg" alt="A person using a computer" />
+	</Story>
+</Canvas>
+
+** External url **
+
+<Canvas>
+	<Story name="External url">
+		<Image
+			src="https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/HY6LDPEW4BBFDLBYD4S3S7LZ3E.jpg"
+			alt="A person posing"
+			height={300}
+			width={300}
+			resizedOptions={{
+				auth: "f314a3f3b86665d1ef144a4a429324658d253fe5af94719822deee11be985738",
+			}}
+			responsiveImages={[100, 200, 1000, 1500]}
+			resizerURL="https://themesinternal-themesinternal-sandbox.web.arc-cdn.net/resizer/v2/"
+			sizes={[{ isDefault: true, sourceSizeValue: "200px" }]}
+		/>
 	</Story>
 </Canvas>

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -111,4 +111,53 @@ describe("Image", () => {
 			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100&height=50 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200&height=100 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300&height=150 300w"
 		);
 	});
+
+	it("should render srcset without height and width using responsive images array", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"srcset",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300 300w"
+		);
+	});
+
+	it("should only render positive integer responsive images array", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300, -100, "yes", true]}
+			/>
+		);
+
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"srcset",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300 300w"
+		);
+	});
+
+	it("should render srcset using responsive images array with height and width", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret", height: 100, width: 50 }}
+				responsiveImages={[100, 200, 300, -100, "yes", true]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"srcset",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100&height=200 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200&height=400 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300&height=600 300w"
+		);
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -194,4 +194,21 @@ describe("Image", () => {
 			"(min-width: 600px) 75vw, (min-width: 500px) 100vw, 50vw"
 		);
 	});
+
+	it("uses the first default size provided", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300]}
+				sizes={[
+					{ sourceSizeValue: "50vw", isDefault: true },
+					{ sourceSizeValue: "75vw", isDefault: true },
+				]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("sizes", "50vw");
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -211,4 +211,18 @@ describe("Image", () => {
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("sizes", "50vw");
 	});
+
+	it("handles not having a default size", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300]}
+				sizes={[{ sourceSizeValue: "50vw", mediaCondition: "(min-width: 600px)" }]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("sizes", "(min-width: 600px) 50vw, ");
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -45,7 +45,7 @@ describe("Image", () => {
 
 	it("should render height and width if height and width", () => {
 		render(
-			<Image src="test-image.jpg" resizedOptions={{ width: 100, height: 100, auth: "secret" }} />
+			<Image src="test-image.jpg" resizedOptions={{ auth: "secret" }} width={100} height={100} />
 		);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("height", "100");
@@ -53,7 +53,7 @@ describe("Image", () => {
 	});
 
 	it("should render only height if height and no width", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ height: 100, auth: "secret" }} />);
+		render(<Image src="test-image.jpg" resizedOptions={{ auth: "secret" }} height={100} />);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("height", "100");
 		expect(element).not.toHaveAttribute("width");
@@ -101,8 +101,10 @@ describe("Image", () => {
 			<Image
 				src="/test-image.jpg"
 				resizerURL="https://resizer.example.com"
-				resizedOptions={{ filter: 70, quality: 50, height: 50, width: 100, auth: "secret" }}
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
+				height={50}
+				width={100}
 			/>
 		);
 		const element = screen.getByRole("img");
@@ -150,7 +152,9 @@ describe("Image", () => {
 			<Image
 				src="/test-image.jpg"
 				resizerURL="https://resizer.example.com"
-				resizedOptions={{ filter: 70, quality: 50, auth: "secret", height: 100, width: 50 }}
+				height={100}
+				width={50}
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300, -100, "yes", true]}
 			/>
 		);

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -40,4 +40,22 @@ describe("Image", () => {
 		expect(element).toHaveAttribute("height", "100");
 		expect(element).not.toHaveAttribute("width");
 	});
+
+	it("should pass in a first option with ? into the source with the resized image option", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70 }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70");
+	});
+
+	it("should pass in many options into the source with the resized image option", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70, quality: 50 }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&quality=50");
+	});
+
+	it("should pass in boolean as a string into the source with the resized image option", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ filter: true, fancy: false }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=true&fancy=false");
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -20,6 +20,22 @@ describe("Image", () => {
 		expect(element).toHaveClass(ORIGINAL_CLASSES);
 	});
 
+	it("should render additional classes with an auth token", () => {
+		const ORIGINAL_CLASSES = "c-image";
+		const ADDITIONAL_CLASSES = "additionalClass1 additionalClass2";
+		render(
+			<Image
+				className={ADDITIONAL_CLASSES}
+				resizedOptions={{ auth: "secret" }}
+				src="test-image.jpg"
+			/>
+		);
+
+		const element = screen.getByRole("img");
+		expect(element).toHaveClass(ADDITIONAL_CLASSES);
+		expect(element).toHaveClass(ORIGINAL_CLASSES);
+	});
+
 	it("should render no height and no width if no height and width", () => {
 		render(<Image src="test-image.jpg" />);
 		const element = screen.getByRole("img");
@@ -28,35 +44,41 @@ describe("Image", () => {
 	});
 
 	it("should render height and width if height and width", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ width: 100, height: 100 }} />);
+		render(
+			<Image src="test-image.jpg" resizedOptions={{ width: 100, height: 100, auth: "secret" }} />
+		);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("height", "100");
 		expect(element).toHaveAttribute("width", "100");
 	});
 
 	it("should render only height if height and no width", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ height: 100 }} />);
+		render(<Image src="test-image.jpg" resizedOptions={{ height: 100, auth: "secret" }} />);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("height", "100");
 		expect(element).not.toHaveAttribute("width");
 	});
 
 	it("should pass in a first option with ? into the source with the resized image option", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70 }} />);
+		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70, auth: "secret" }} />);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&auth=secret");
 	});
 
 	it("should pass in many options into the source with the resized image option", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70, quality: 50 }} />);
+		render(
+			<Image src="test-image.jpg" resizedOptions={{ filter: 70, quality: 50, auth: "secret" }} />
+		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&quality=50");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&quality=50&auth=secret");
 	});
 
 	it("should pass in boolean as a string into the source with the resized image option", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ filter: true, fancy: false }} />);
+		render(
+			<Image src="test-image.jpg" resizedOptions={{ filter: true, fancy: false, auth: "secret" }} />
+		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=true&fancy=false");
+		expect(element).toHaveAttribute("src", "test-image.jpg?filter=true&fancy=false&auth=secret");
 	});
 
 	it("should prefix the src with the resizer url and add query parameters", () => {
@@ -64,13 +86,13 @@ describe("Image", () => {
 			<Image
 				src="/test-image.jpg"
 				resizerURL="https://resizer.example.com"
-				resizedOptions={{ filter: 70, quality: 50 }}
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 			/>
 		);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute(
 			"src",
-			"https://resizer.example.com/test-image.jpg?filter=70&quality=50"
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret"
 		);
 	});
 
@@ -79,14 +101,14 @@ describe("Image", () => {
 			<Image
 				src="/test-image.jpg"
 				resizerURL="https://resizer.example.com"
-				resizedOptions={{ filter: 70, quality: 50, height: 50, width: 100 }}
+				resizedOptions={{ filter: 70, quality: 50, height: 50, width: 100, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 			/>
 		);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute(
 			"srcset",
-			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=100&height=50 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=200&height=100 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=300&height=150 300w"
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100&height=50 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200&height=100 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300&height=150 300w"
 		);
 	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -160,4 +160,38 @@ describe("Image", () => {
 			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=100&height=200 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=200&height=400 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret&width=300&height=600 300w"
 		);
 	});
+	it("passes in sizes array of object string default rendered", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300]}
+				sizes={[{ isDefault: true, sourceSizeValue: "50vw" }]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("sizes", "50vw");
+	});
+
+	it("passes in sizes array of object with many sizes", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+				responsiveImages={[100, 200, 300]}
+				sizes={[
+					{ sourceSizeValue: "50vw", isDefault: true },
+					{ sourceSizeValue: "75vw", mediaCondition: "(min-width: 600px)" },
+					{ sourceSizeValue: "100vw", mediaCondition: "(min-width: 500px)" },
+				]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"sizes",
+			"(min-width: 600px) 75vw, (min-width: 500px) 100vw, 50vw"
+		);
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -73,4 +73,20 @@ describe("Image", () => {
 			"https://resizer.example.com/test-image.jpg?filter=70&quality=50"
 		);
 	});
+
+	it("should handle width and height passed into responsive images and render srcset", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50, height: 50, width: 100 }}
+				responsiveImages={[100, 200, 300]}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"srcset",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=100&height=50 100w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=200&height=100 200w, https://resizer.example.com/test-image.jpg?filter=70&quality=50&width=300&height=150 300w"
+		);
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -19,4 +19,25 @@ describe("Image", () => {
 		expect(element).toHaveClass(ADDITIONAL_CLASSES);
 		expect(element).toHaveClass(ORIGINAL_CLASSES);
 	});
+
+	it("should render no height and no width if no height and width", () => {
+		render(<Image src="test-image.jpg" />);
+		const element = screen.getByRole("img");
+		expect(element).not.toHaveAttribute("height");
+		expect(element).not.toHaveAttribute("width");
+	});
+
+	it("should render height and width if height and width", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ width: 100, height: 100 }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("height", "100");
+		expect(element).toHaveAttribute("width", "100");
+	});
+
+	it("should render only height if height and no width", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ height: 100 }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("height", "100");
+		expect(element).not.toHaveAttribute("width");
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -58,4 +58,19 @@ describe("Image", () => {
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("src", "test-image.jpg?filter=true&fancy=false");
 	});
+
+	it("should prefix the src with the resizer url and add query parameters", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ filter: 70, quality: 50 }}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50"
+		);
+	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -227,6 +227,6 @@ describe("Image", () => {
 			/>
 		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("sizes", "(min-width: 600px) 50vw, ");
+		expect(element).toHaveAttribute("sizes", "(min-width: 600px) 50vw");
 	});
 });


### PR DESCRIPTION
## Ticket

- [TMEDIA-852](https://arcpublishing.atlassian.net/jira/software/c/projects/TMEDIA/boards/875?modal=detail&selectedIssue=TMEDIA-843&assignee=5e387d6a1b1d910e5dfd7a9b)

## Description

Since the image component does not currently handle responsive images, we’re going to utilize the power of v2 resizer to do so. 

Please remember that, like discussed in tech party, network conditions, browser, and screen web pixel density may affect which image is displayed.  

We want to make this forward-compatible with any resizer v2 improvements or features. So this will accept fields via an object that can theoretically pass in any field.
## Acceptance Criteria

- [x] Remove width and height fields from existing Image component in the arc themes components repo
- [x] Add resizerOptions field that takes in an object with keys for current or future resizer v2 query parameters.
- [x] If empty resizerOptions, then render raw image with no width or height.
- [x] The width and height properties of the img tag are determined by what’s inside the resizerOptions
- [x] Create storybook examples for no width, no height, width and height, and various available combinations of resizer options
- [x] Add a responsiveImages array of numbers. These are the width descriptor. Must be positive integers
- [x] The responsiveImages and the resizerOptions will be responsible for creating the srcSet attribute in the image tag 
- [x] The width in the resizerOptions would multiply by each responsiveImages integer to create a srcSet's url with the filters as well as the width descriptor 
- [x] Cleanup some of the logic around generating a srcset. 
- [x] Ensure that, if width is not required in the resizedOptions, then the image responsive array will be solely responsible for setting the width. 
- [x] Don't render the srcset if empty responsive images array.
- [ ] This srcSet array mapper should be in the utils folder for reusability -> investigating patterns now, but open to feedback
- [x] Take in a sizes field that is an array of objects 
- [x] Each item needs a mediaCondition and a sourceSizeValue, except for one isDefault
- [x] There must be one isDefault object. This will be the last in the string of the generated sizes property 
- [x] If there is more than one isDefault, then use the first one specified


## Test Steps

1. Checkout branch - `git checkout TMEDIA-852-image-component`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Go to the image component stories

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
