### PR TITLE
Add getVideoFromANS functon from engine-themes-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ import formatCredits from "./src/utils/format-credits";
 import formatPowaVideoEmbed from "./src/utils/format-powa-video-embed";
 import formatURL from "./src/utils/format-url";
 import getImageFromANS from "./src/utils/get-image-from-ans";
+import getVideoFromANS from "./src/utils/get-video-from-ans";
 import useInterval from "./src/utils/hooks/use-interval";
 import isServerSide from "./src/utils/is-server-side";
 import serialJoin from "./src/utils/serial-join";
@@ -43,6 +44,7 @@ export {
 	formatPowaVideoEmbed,
 	formatURL,
 	getImageFromANS,
+	getVideoFromANS,
 	Grid,
 	Heading,
 	HeadingSection,

--- a/src/utils/get-video-from-ans/getVideoFromANS.test.js
+++ b/src/utils/get-video-from-ans/getVideoFromANS.test.js
@@ -1,0 +1,70 @@
+import getVideoFromANS from ".";
+
+const contentTypeImageBasicPromo = {
+	type: "story",
+	promo_items: {
+		basic: {
+			type: "image",
+		},
+	},
+};
+const contentTypeImageLeadPromo = {
+	type: "story",
+	promo_items: {
+		lead_art: {
+			type: "image",
+		},
+	},
+};
+const contentTypeVideo = {
+	type: "video",
+	embed_html: '<div class="somehtml"></div>',
+};
+const contentTypeVideoPromo = {
+	type: "story",
+	promo_items: {
+		lead_art: {
+			...contentTypeVideo,
+		},
+	},
+};
+
+describe("getVideoFromANS()", () => {
+	describe('when content type is "story"', () => {
+		it('should return "undefined" when content has non-"video" basic art', () => {
+			const vidEmbed = getVideoFromANS(contentTypeImageBasicPromo);
+			expect(vidEmbed).not.toBeDefined();
+		});
+
+		it('should return "undefined" when content has non-"video" lead art', () => {
+			const vidEmbed = getVideoFromANS(contentTypeImageLeadPromo);
+			expect(vidEmbed).not.toBeDefined();
+		});
+
+		it('should return "embed_html" when content has "video" lead art', () => {
+			const vidEmbed = getVideoFromANS(contentTypeVideoPromo);
+			expect(vidEmbed).toBeDefined();
+			expect(vidEmbed).toEqual(contentTypeVideo.embed_html);
+		});
+	});
+
+	describe('when content type is "video"', () => {
+		it('should return "undefined" when embed does not exist', () => {
+			const vidEmbed = getVideoFromANS({ type: "video" });
+			expect(vidEmbed).not.toBeDefined();
+		});
+
+		it('should return "embed_html" when embed exists', () => {
+			const vidEmbed = getVideoFromANS(contentTypeVideo);
+			expect(vidEmbed).toBeDefined();
+			expect(vidEmbed).toEqual(contentTypeVideo.embed_html);
+		});
+	});
+
+	describe("when content is undefined", () => {
+		it('should return "undefined" when no valid content', () => {
+			const vidEmbed = getVideoFromANS(undefined);
+			expect(vidEmbed).not.toBeDefined();
+		});
+	});
+});

--- a/src/utils/get-video-from-ans/index.js
+++ b/src/utils/get-video-from-ans/index.js
@@ -1,0 +1,12 @@
+const embedSource = (content) =>
+	({
+		video: content,
+		story: content?.promo_items?.lead_art,
+	}[content?.type]);
+
+const getVideoFromANS = (content) => {
+	const source = embedSource(content);
+	return source?.type === "video" ? source?.embed_html : undefined;
+};
+
+export default getVideoFromANS;


### PR DESCRIPTION
## Ticket

- [TMEDIA-740](https://arcpublishing.atlassian.net/browse/TMEDIA-740)

## Description

Moving engine-theme-sdk `extractVideoEmbedFromStory` to `getVideoFromANS`

## Test Steps

1. Checkout branch - `git checkout tmedia-740`
2. Run Tests `npm run test`

![image](https://user-images.githubusercontent.com/2287238/179832945-e9fe2749-76dc-4bd9-882b-b7ad2a732d15.png)

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
