### PR TITLE
Image Component - Switch to max-inline-size and 100%

### DIFF
--- a/src/components/image/_index.scss
+++ b/src/components/image/_index.scss
@@ -5,7 +5,7 @@
 	font-style: italic;
 	// don't want the image to grow larger than itself
 	// without it, we couldn't use height and width for reserving space and srcset and sizes
-	inline-size: max-content;
+	max-inline-size: 100%;
 	// don't want the image to shrink smaller than its intrinsic size due to height and width set
 	block-size: auto;
 


### PR DESCRIPTION
## Description

This address a regression with the image updates causing some images to break out of their containers and be their full width, as per https://web.dev/learn/design/responsive-images/ we should be using `max-inline-size: 100%;`

Currently only affecting Quilted image block - see Development environment on Arc Commerce

## Test Steps

Storybook and Chromatic

1. Checkout branch - `git checkout image-inline-fix`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Image storybook documentation

You can also test the updates by linking the components repo locally in a feature pack using `THEME_COMPONENTS_REPO` value in your `.env` file

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
