### PR TITLE
TBRANDS-98 - Update Details component to render children as HTML

### DIFF
--- a/src/components/details/_index.scss
+++ b/src/components/details/_index.scss
@@ -44,11 +44,11 @@
 			@include scss.component-properties("details-with-icon-open");
 		}
 
-		&[open] &__summary-text {
+		&[open] .c-details__summary-text {
 			@include scss.component-properties("details-with-icon-open-summary-text");
 		}
 
-		&[open] &__summary-icon {
+		&[open] .c-details__summary-icon {
 			@include scss.component-properties("details-with-icon-open-summary-icon");
 		}
 

--- a/src/components/details/index.jsx
+++ b/src/components/details/index.jsx
@@ -2,7 +2,16 @@ import PropTypes from "prop-types";
 
 const COMPONENT_CLASS_NAME = "c-details";
 
-const Details = ({ children, className, icon, iconPlacement, open, summary, ...rest }) => {
+const Details = ({
+	children,
+	childrenHTML,
+	className,
+	icon,
+	iconPlacement,
+	open,
+	summary,
+	...rest
+}) => {
 	const classNames = [COMPONENT_CLASS_NAME, icon && `${COMPONENT_CLASS_NAME}--with-icon`, className]
 		.filter((classString) => classString)
 		.join(" ");
@@ -15,12 +24,13 @@ const Details = ({ children, className, icon, iconPlacement, open, summary, ...r
 				<span className={`${COMPONENT_CLASS_NAME}__summary-text`}>{summary}</span>
 				{iconPlacement === "right" && IconOutput}
 			</summary>
-			{children}
+			{childrenHTML ? <p dangerouslySetInnerHTML={{ __html: children }} /> : children}
 		</details>
 	);
 };
 
 Details.defaultProps = {
+	childrenHTML: false,
 	iconPlacement: "right",
 	open: false,
 };
@@ -29,7 +39,9 @@ Details.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
-	children: PropTypes.node.isRequired,
+	children: PropTypes.node,
+	/** Falg to denote if the children should be rendered as HTML using dangerouslySetInnerHTML */
+	childrenHTML: PropTypes.bool,
 	/** Icon to be used instead of default CSS behaviour for summary */
 	icon: PropTypes.node,
 	/** Denote the Icon placement in the summary, left or right */

--- a/src/components/details/index.jsx
+++ b/src/components/details/index.jsx
@@ -40,7 +40,7 @@ Details.propTypes = {
 	className: PropTypes.string,
 	/** The text, images or any node that will be displayed within the component */
 	children: PropTypes.node,
-	/** Falg to denote if the children should be rendered as HTML using dangerouslySetInnerHTML */
+	/** Flag to denote if the children should be rendered as HTML using dangerouslySetInnerHTML */
 	childrenHTML: PropTypes.bool,
 	/** Icon to be used instead of default CSS behaviour for summary */
 	icon: PropTypes.node,

--- a/src/components/details/index.stories.mdx
+++ b/src/components/details/index.stories.mdx
@@ -34,6 +34,16 @@ const Feature = () => <Details summary="Summary">Details Text</Details>;
 	</Story>
 </Canvas>
 
+** Details with HTML Content **
+
+<Canvas>
+	<Story name="Details with HTML Context">
+		<Details summary="Summary" open childrenHTML>
+			{"Details Text <br />Details Text"}
+		</Details>
+	</Story>
+</Canvas>
+
 ** Details with Icon **
 
 <Canvas>

--- a/src/components/details/index.test.jsx
+++ b/src/components/details/index.test.jsx
@@ -34,7 +34,7 @@ describe("Details", () => {
 	});
 
 	it("should render children as HTML", () => {
-		const childMockHTML = "Hello<br />World";
+		const childMockHTML = "Hello<br />World \u00F7";
 		const { container } = render(
 			<Details summary="Summary" icon={<>Icon</>} iconPlacement="left" childrenHTML>
 				{childMockHTML}
@@ -45,6 +45,6 @@ describe("Details", () => {
 		expect(screen.queryByText("Icon")).not.toBeNull();
 
 		const element = container.querySelector("details > p");
-		expect(element.outerHTML).toEqual("<p>Hello<br>World</p>");
+		expect(element.outerHTML).toEqual("<p>Hello<br>World ÷</p>");
 	});
 });

--- a/src/components/details/index.test.jsx
+++ b/src/components/details/index.test.jsx
@@ -12,12 +12,12 @@ describe("Details", () => {
 	it("should render additional classes", () => {
 		const ORIGINAL_CLASSES = "c-details";
 		const ADDITIONAL_CLASSES = "additionalClass1 additionalClass2";
-		render(
+		const { container } = render(
 			<Details className={ADDITIONAL_CLASSES} summary="Summary">
 				Hello World
 			</Details>
 		);
-		const element = screen.queryByText("Hello World");
+		const element = container.querySelector("details");
 		expect(element).toHaveClass(ADDITIONAL_CLASSES);
 		expect(element).toHaveClass(ORIGINAL_CLASSES);
 	});
@@ -31,5 +31,20 @@ describe("Details", () => {
 		expect(screen.queryByText("Summary")).not.toBeNull();
 		expect(screen.queryByText("Hello World")).not.toBeNull();
 		expect(screen.queryByText("Icon")).not.toBeNull();
+	});
+
+	it("should render children as HTML", () => {
+		const childMockHTML = "Hello<br />World";
+		const { container } = render(
+			<Details summary="Summary" icon={<>Icon</>} iconPlacement="left" childrenHTML>
+				{childMockHTML}
+			</Details>
+		);
+
+		expect(screen.queryByText("Summary")).not.toBeNull();
+		expect(screen.queryByText("Icon")).not.toBeNull();
+
+		const element = container.querySelector("details > p");
+		expect(element.outerHTML).toEqual("<p>Hello<br>World</p>");
 	});
 });


### PR DESCRIPTION
## Ticket

- [TBRANDS-98](https://arcpublishing.atlassian.net/browse/TBRANDS-98)

## Description

The children passed to the details component could have HTML - this update gives the consumer the ability to flag that and allow for the component to render the children as HTML using `dangerouslySetInnerHTML` - this is needed for when the children could have unicode characters and react children will not render those


## Test Steps

Can test via chromatic and unit tests

1. Checkout branch - `git checkout TBRANDS-98-details-htmll`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the details storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
