### PR TITLE
FIX update sizes default to remove warning

### DIFF
--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -95,7 +95,7 @@ Image.defaultProps = {
 	resizedOptions: {},
 	resizerURL: "",
 	responsiveImages: [],
-	sizes: "",
+	sizes: [],
 	width: null,
 	height: null,
 };


### PR DESCRIPTION
before 
- warning on external image with no sizes prop
<img width="1280" alt="Screen Shot 2022-07-28 at 10 42 01" src="https://user-images.githubusercontent.com/5950956/181580885-22245635-687d-4cb6-905a-1d4048f1092d.png">


after 
- no warning on external images with no sizes pro
<img width="749" alt="Screen Shot 2022-07-28 at 10 42 17" src="https://user-images.githubusercontent.com/5950956/181580857-8b25674e-80b2-43dd-8220-c687d5dc24dc.png">
p