### PR TITLE
Add [open] summary CSS selector and Sass hook

### DIFF
--- a/src/components/details/_index.scss
+++ b/src/components/details/_index.scss
@@ -13,18 +13,6 @@
 		@include scss.component-properties("details-summary-icon");
 	}
 
-	&[open] {
-		@include scss.component-properties("details-open");
-	}
-
-	&[open] &__summary-text {
-		@include scss.component-properties("details-open-summary-text");
-	}
-
-	&[open] &__summary-icon {
-		@include scss.component-properties("details-open-summary-icon");
-	}
-
 	&--with-icon {
 		summary {
 			align-items: center;
@@ -53,6 +41,22 @@
 		}
 
 		@include scss.component-properties("details-with-icon");
+	}
+
+	&[open] {
+		@include scss.component-properties("details-open");
+	}
+
+	&[open] summary {
+		@include scss.component-properties("details-open-summary");
+	}
+
+	&[open] &__summary-text {
+		@include scss.component-properties("details-open-summary-text");
+	}
+
+	&[open] &__summary-icon {
+		@include scss.component-properties("details-open-summary-icon");
 	}
 
 	@include scss.component-properties("details");

--- a/src/components/details/_index.scss
+++ b/src/components/details/_index.scss
@@ -15,6 +15,11 @@
 
 	&--with-icon {
 		summary {
+			// Safari will display default marker with icon if not explicitly stated to remove it
+			&::-webkit-details-marker {
+				display: none;
+			}
+
 			align-items: center;
 			display: flex;
 			@include scss.component-properties("details-with-icon-summary");


### PR DESCRIPTION
## Ticket

- [TBANDS-98](https://arcpublishing.atlassian.net/browse/TBRANDS-98)

## Description

Add CSS for `&[open] summary` with Sass hooks
Remove marker by default in the `--with-icon` class

Updates needed for https://github.com/WPMedia/arc-themes-blocks/pull/1456

## Test Steps

Chromatic and local

1. Checkout branch - `git checkout TBRANDS-98-add-summary-open-hook`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Details storybook documentation

Test in Safari to validate marker is not shown when using Icon

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
