### PR TITLE
fix: If client passes in height and width to resized options, filter …

### DIFF
--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -33,11 +33,20 @@ const Image = ({
 		);
 	}
 
-	// "https://resizer.com/" + "image.jpg" + "?auth=secret&filter=true"
+	// height and width should only be set on the image top-level
+	// we're filtered out resized options so that we have consistent approach to setting dimensions
+	// for aspect ratio as well as the img element itself for cls
+	const {
+		width: _unusedWidth,
+		height: _unusedHeight,
+		...resizedOptionsNoDimensions
+	} = resizedOptions;
+
+	// "https://resizer.com/" + "image.jpg" + "?" + "auth=secret&filter=true"
 	const srcWithOptionsWithoutHeightWidth = resizerURL.concat(
 		src,
 		"?",
-		new URLSearchParams(resizedOptions).toString()
+		new URLSearchParams(resizedOptionsNoDimensions).toString()
 	);
 
 	// add the height and width to the default src if they exist

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -14,7 +14,7 @@ Crucially, an "auth" key will allow the image to be resized. This object will re
 
 For responsive images, the goal is to provide options given the media conditions, like screen size, provided using the "sizes" prop that takes in an array of objects. This is will render the [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) string.
 
-Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `resizedOptions` and the `responsiveImages` prop. The `resizedOptions` will also provide the aspect ratio, with `resizedOptions.height` and `resizedOptions.width`, needed to make the `srcset` available images.
+Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `resizedOptions` and the `responsiveImages` prop.
 
 The width and height prop are used to set the aspect ratio of the responsive images. For instance, if you set the width of 200 and height of 100, you're using an aspect ratio of 2. Then, if you're using `responsiveImages` of `[100, 200, 300]`, you'll get the height and width of the following: width=100, height=50 for 100, width=200 height=100 for 200, and width=300 height=150 for 300. In this way, the images are responsive based off of width. You are also opting into browser best practices of setting any width to give the browser a hint of how big the image will be. However, the image that's set based off of the `sizes` `mediaCondition` and `sourceSizeValue` will determine how big the image actually will be.
 

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -22,6 +22,8 @@ If you don't set a `responsiveImages` array, you will have no responsive image o
 
 For more information on responsive image best practices, please see: https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images. We are using sizes and srcset based off of these practices, using arc resizer v2 auth and filters. If you seek more customization, you can create your own image component as well. Or, please refer to the Picture component if you require different image art direction or image.
 
+NOTE: The `resizedOptions` will not be used for the height and width: the `height` and `width` prop will only be used for setting width and height of the `<img>` as well as for calculating the aspect ratio used to generated the `<img>`'s srcset.
+
 ## Usage
 
 ```jsx

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -14,7 +14,7 @@ Crucially, an "auth" key will allow the image to be resized. This object will re
 
 For responsive images, the goal is to provide options given the media conditions, like screen size, provided using the "sizes" prop that takes in an array of objects. This is will render the [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) string.
 
-Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `resizedOptions` and the `responsiveImages` prop.
+Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `sizes` and the `responsiveImages` props.
 
 The width and height prop are used to set the aspect ratio of the responsive images. For instance, if you set the width of 200 and height of 100, you're using an aspect ratio of 2. Then, if you're using `responsiveImages` of `[100, 200, 300]`, you'll get the height and width of the following: width=100, height=50 for 100, width=200 height=100 for 200, and width=300 height=150 for 300. In this way, the images are responsive based off of width. You are also opting into browser best practices of setting any width to give the browser a hint of how big the image will be. However, the image that's set based off of the `sizes` `mediaCondition` and `sourceSizeValue` will determine how big the image actually will be.
 

--- a/src/components/image/index.stories.mdx
+++ b/src/components/image/index.stories.mdx
@@ -14,7 +14,7 @@ Crucially, an "auth" key will allow the image to be resized. This object will re
 
 For responsive images, the goal is to provide options given the media conditions, like screen size, provided using the "sizes" prop that takes in an array of objects. This is will render the [sizes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes) string.
 
-Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the `sizes` and the `responsiveImages` props.
+Given the sizes specified, the browser will choose the best image to display from the `srcset` attribute created given the the `responsiveImages` prop.
 
 The width and height prop are used to set the aspect ratio of the responsive images. For instance, if you set the width of 200 and height of 100, you're using an aspect ratio of 2. Then, if you're using `responsiveImages` of `[100, 200, 300]`, you'll get the height and width of the following: width=100, height=50 for 100, width=200 height=100 for 200, and width=300 height=150 for 300. In this way, the images are responsive based off of width. You are also opting into browser best practices of setting any width to give the browser a hint of how big the image will be. However, the image that's set based off of the `sizes` `mediaCondition` and `sourceSizeValue` will determine how big the image actually will be.
 

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -249,5 +249,7 @@ describe("Image", () => {
 			"srcset",
 			"https://resizer.example.com/test-image.jpg?auth=secret&width=100&height=200 100w, https://resizer.example.com/test-image.jpg?auth=secret&width=200&height=400 200w, https://resizer.example.com/test-image.jpg?auth=secret&width=300&height=600 300w"
 		);
+		expect(element).toHaveAttribute("height", "100");
+		expect(element).toHaveAttribute("width", "50");
 	});
 });

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -229,4 +229,25 @@ describe("Image", () => {
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("sizes", "(min-width: 600px) 50vw");
 	});
+	it("should only allow the top-level height and width to set the src and srcset", () => {
+		render(
+			<Image
+				src="/test-image.jpg"
+				resizerURL="https://resizer.example.com"
+				resizedOptions={{ auth: "secret", width: 55, height: 144 }}
+				responsiveImages={[100, 200, 300]}
+				height={100}
+				width={50}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/test-image.jpg?auth=secret&width=50&height=100"
+		);
+		expect(element).toHaveAttribute(
+			"srcset",
+			"https://resizer.example.com/test-image.jpg?auth=secret&width=100&height=200 100w, https://resizer.example.com/test-image.jpg?auth=secret&width=200&height=400 200w, https://resizer.example.com/test-image.jpg?auth=secret&width=300&height=600 300w"
+		);
+	});
 });


### PR DESCRIPTION
- addressed concern that height and width -- if wrongly passed in -- would be set twice on the resized options