### PR TITLE
Image Updates

### DIFF
--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -15,22 +15,17 @@ const Image = ({
 	height,
 	sizes,
 }) => {
-	// get the default height and width of the image
-	// use aspect ratio to generate other sizes
 	const { auth } = resizedOptions;
+	const componentClassNames = className
+		? `${COMPONENT_CLASS_NAME} ${className}`
+		: COMPONENT_CLASS_NAME;
 
-	if (!auth) {
+	if (!auth || !resizerURL) {
 		// eslint-disable-next-line no-console
 		console.error("No auth token provided for resizer");
 
 		return (
-			<img
-				alt={alt}
-				className={className ? `${COMPONENT_CLASS_NAME} ${className}` : COMPONENT_CLASS_NAME}
-				src={src}
-				width={width}
-				height={height}
-			/>
+			<img alt={alt} className={componentClassNames} src={src} width={width} height={height} />
 		);
 	}
 
@@ -56,20 +51,21 @@ const Image = ({
 			)
 			.join(", ") || null;
 
-	const responsiveSizes = sizes
-		? sizes
-				.filter(({ isDefault }) => !isDefault)
-				.map(({ mediaCondition, sourceSizeValue }) => `${mediaCondition} ${sourceSizeValue}`)
-				.concat(
-					sizes.find((currentSizeObject) => currentSizeObject.isDefault)?.sourceSizeValue || []
-				)
-				.join(", ")
-		: null;
+	const responsiveSizes =
+		sizes && sizes.length
+			? sizes
+					.filter(({ isDefault }) => !isDefault)
+					.map(({ mediaCondition, sourceSizeValue }) => `${mediaCondition} ${sourceSizeValue}`)
+					.concat(
+						sizes.find((currentSizeObject) => currentSizeObject.isDefault)?.sourceSizeValue || []
+					)
+					.join(", ")
+			: null;
 
 	return (
 		<img
 			alt={alt}
-			className={className ? `${COMPONENT_CLASS_NAME} ${className}` : COMPONENT_CLASS_NAME}
+			className={componentClassNames}
 			height={height}
 			loading={loading}
 			src={defaultSrc}

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -43,9 +43,33 @@ describe("Image", () => {
 		expect(element).not.toHaveAttribute("width");
 	});
 
+	it("should use src if resizerURL and no Auth", () => {
+		render(
+			<Image
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ filter: 70 }}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("src", "test-image.jpg");
+	});
+
+	it("should use src if no resizerURL and no Auth", () => {
+		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70 }} />);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute("src", "test-image.jpg");
+	});
+
 	it("should render height and width if height and width", () => {
 		render(
-			<Image src="test-image.jpg" resizedOptions={{ auth: "secret" }} width={100} height={100} />
+			<Image
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ auth: "secret" }}
+				width={100}
+				height={100}
+			/>
 		);
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("height", "100");
@@ -60,32 +84,55 @@ describe("Image", () => {
 	});
 
 	it("should pass in a first option with ? into the source with the resized image option", () => {
-		render(<Image src="test-image.jpg" resizedOptions={{ filter: 70, auth: "secret" }} />);
+		render(
+			<Image
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ filter: 70, auth: "secret" }}
+			/>
+		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&auth=secret");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/test-image.jpg?filter=70&auth=secret"
+		);
 	});
 
 	it("should pass in many options into the source with the resized image option", () => {
 		render(
-			<Image src="test-image.jpg" resizedOptions={{ filter: 70, quality: 50, auth: "secret" }} />
+			<Image
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
+			/>
 		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=70&quality=50&auth=secret");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/test-image.jpg?filter=70&quality=50&auth=secret"
+		);
 	});
 
 	it("should pass in boolean as a string into the source with the resized image option", () => {
 		render(
-			<Image src="test-image.jpg" resizedOptions={{ filter: true, fancy: false, auth: "secret" }} />
+			<Image
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ filter: true, fancy: false, auth: "secret" }}
+			/>
 		);
 		const element = screen.getByRole("img");
-		expect(element).toHaveAttribute("src", "test-image.jpg?filter=true&fancy=false&auth=secret");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/test-image.jpg?filter=true&fancy=false&auth=secret"
+		);
 	});
 
 	it("should prefix the src with the resizer url and add query parameters", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 			/>
 		);
@@ -99,8 +146,8 @@ describe("Image", () => {
 	it("should handle width and height passed into responsive images and render srcset", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 				height={50}
@@ -117,8 +164,8 @@ describe("Image", () => {
 	it("should render srcset without height and width using responsive images array", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 			/>
@@ -133,8 +180,8 @@ describe("Image", () => {
 	it("should only render positive integer responsive images array", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300, -100, "yes", true]}
 			/>
@@ -150,8 +197,8 @@ describe("Image", () => {
 	it("should render srcset using responsive images array with height and width", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				height={100}
 				width={50}
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
@@ -167,8 +214,8 @@ describe("Image", () => {
 	it("passes in sizes array of object string default rendered", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 				sizes={[{ isDefault: true, sourceSizeValue: "50vw" }]}
@@ -181,8 +228,8 @@ describe("Image", () => {
 	it("passes in sizes array of object with many sizes", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 				sizes={[
@@ -202,8 +249,8 @@ describe("Image", () => {
 	it("uses the first default size provided", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 				sizes={[
@@ -219,8 +266,8 @@ describe("Image", () => {
 	it("handles not having a default size", () => {
 		render(
 			<Image
-				src="/test-image.jpg"
-				resizerURL="https://resizer.example.com"
+				src="test-image.jpg"
+				resizerURL="https://resizer.example.com/"
 				resizedOptions={{ filter: 70, quality: 50, auth: "secret" }}
 				responsiveImages={[100, 200, 300]}
 				sizes={[{ sourceSizeValue: "50vw", mediaCondition: "(min-width: 600px)" }]}

--- a/src/components/picture/_children/source.jsx
+++ b/src/components/picture/_children/source.jsx
@@ -9,7 +9,7 @@ const Source = ({ height, media, resizedOptions, resizerURL, src, width, ...rest
 				height={height}
 				media={media}
 				srcSet={
-					resizedOptions?.auth
+					resizedOptions?.auth && resizerURL
 						? formatSrc(resizerURL.concat(src), resizedOptions, width, height)
 						: src
 				}


### PR DESCRIPTION
## Description

Only add `resizerOptions` when a `resizerURL` is present - currently we are appendeding query strings to images that do not have a resizer url. This update ensure we are only adding query strings to `src` urls when we have a resizerURL

## Test Steps

Test Updates, Chromatic

1. Checkout branch - `git checkout image-src-updates`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the Image/Picture storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
