### PR TITLE
tmedia 734: Hide additional controls if no other carousel items

### DIFF
--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -378,7 +378,7 @@ const Carousel = ({
 							{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
 						</p>
 					) : null}
-					{showAdditionalSlideControls ? (
+					{carouselItems.length > 1 && showAdditionalSlideControls ? (
 						<div className={`${COMPONENT_CLASS_NAME}__additional-controls`}>
 							{slide !== slidesToShow ? resolvedAdditionalPreviousButton : null}
 							{slide !== carouselItems.length && carouselItems.length > 1

--- a/src/components/carousel/index.stories.mdx
+++ b/src/components/carousel/index.stories.mdx
@@ -614,3 +614,17 @@ const Feature = () => (
 		</Carousel>
 	</Story>
 </Canvas>
+
+** No additional slide controls will be shown if one slide and opted in to addition slide controls **
+
+<Canvas>
+	<Story name="No additional slide controls will be shown if one slide and opted in to addition slide controls">
+		<Carousel id="carousel-1" label="Carousel of Images" showAdditionalSlideControls>
+			<Carousel.Item label="Slide 1 of 5">
+				<a href="/">
+					<Image src="/computer-user.jpeg" alt="A person sat down using a laptop computer" />
+				</a>
+			</Carousel.Item>
+		</Carousel>
+	</Story>
+</Canvas>

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -456,6 +456,23 @@ describe("Carousel", () => {
 		});
 	});
 
+	it("hides additional controls if only one child and opted in", async () => {
+		const { container } = render(
+			<Carousel id="carousel-2" label="Carousel Label" showAdditionalSlideControls>
+				<Carousel.Item label="Slide 1 of 1">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		const controlsArea = container.querySelector(".c-carousel__counter-controls-container");
+
+		// hide previous button
+		expect(controlsArea.querySelectorAll(".c-carousel__button--additional-previous")).toHaveLength(
+			0
+		);
+	});
+
 	it("renders a custom start autoplay button", async () => {
 		const customStartButtonText = "Start that autoplay already!";
 		const customStopButtonText = "Stop that autoplay already!";


### PR DESCRIPTION
Before button shown with only one image or no items. Noticed this doing a ticket using carousel 

<img width="1435" alt="Screen Shot 2022-08-24 at 13 29 18" src="https://user-images.githubusercontent.com/5950956/186495707-800aa97b-e675-4581-9e77-fa102da63eda.png">


## Before 
shows previous button when nothing previous
<img width="1429" alt="Screen Shot 2022-08-24 at 13 28 45" src="https://user-images.githubusercontent.com/5950956/186495408-1aa5b766-4ebf-408a-8997-4e0404d91740.png">

## After 
hides previous button when nothing previous
<img width="1437" alt="Screen Shot 2022-08-24 at 13 27 38" src="https://user-images.githubusercontent.com/5950956/186495214-aecffe22-f46e-4618-9810-df7acf3f4743.png">

