### PR TITLE
Tmedia 942 url obj get image

### DIFF
--- a/src/utils/get-image-from-ans/getImageFromANS.test.js
+++ b/src/utils/get-image-from-ans/getImageFromANS.test.js
@@ -192,8 +192,6 @@ describe("when extract an image from a story", () => {
 
 	it("must extract image from basic if lead_art is gallery", () => {
 		const url = getImageFromANS(mockStoryPromoItemsGalleryFocalPoint);
-		const imageUrl =
-			mockStoryPromoItemsGalleryFocalPoint.promo_items.lead_art.promo_items.basic.url;
 
 		expect(url).toEqual({ _id: "P3V3THIJPVGUBLRIIYWKFHZTKA", type: "image", url: "bar.jpg" });
 	});

--- a/src/utils/get-image-from-ans/getImageFromANS.test.js
+++ b/src/utils/get-image-from-ans/getImageFromANS.test.js
@@ -151,17 +151,37 @@ describe("when extract an image from a story", () => {
 		expect(url).toBeNull();
 	});
 	it("must extract image from lead_art.promo_items if is present", () => {
-		const url = getImageFromANS(mockLeadArtVideo);
-		const imageUrl = mockLeadArtVideo.promo_items.lead_art.promo_items.basic.url;
+		const objectWithURL = getImageFromANS(mockLeadArtVideo);
 
-		expect(url).toEqual(imageUrl);
+		expect(objectWithURL).toEqual({
+			caption: "GF Default - A Shallow River Streaming Through A Bed Of Rocks",
+			credits: {},
+			height: 1080,
+			type: "image",
+			url: "https://d22ff27hdsy159.cloudfront.net/11-05-2019/t_9f51049ae2e640ba99b4a7f1763ca5fc_name_t_1c01cadfde48422b857383e38d8553a7_name_Pexels_Videos_2330708__scaled.jpg",
+			version: "0.5.8",
+			width: 1920,
+		});
 	});
 
 	it("must extract image from basic if lead_art image is empty", () => {
-		const url = getImageFromANS(mockLeadArtVideoPromoBasic);
-		const imageUrl = mockLeadArtVideoPromoBasic.promo_items.basic.url;
+		const objectWithURL = getImageFromANS(mockLeadArtVideoPromoBasic);
 
-		expect(url).toEqual(imageUrl);
+		expect(objectWithURL).toEqual({
+			_id: "GH3BDATX7FBZ7DSPPZFD5DPFJM",
+			additional_properties: {
+				fullSizeResizeUrl:
+					"/photo/resize/6BiTyEjupbGWhooSE6SJwf0bPl8=/arc-anglerfish-arc2-prod-corecomponents/public/GH3BDATX7FBZ7DSPPZFD5DPFJM.jpg",
+				ingestionMethod: "manual",
+				keywords: [],
+				mime_type: "image/jpeg",
+				originalName: "tv-test-pattern.jpg",
+				originalUrl:
+					"https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/GH3BDATX7FBZ7DSPPZFD5DPFJM.jpg",
+			},
+			type: "image",
+			url: "https://cloudfront-us-east-1.images.arcpublishing.com/corecomponents/GH3BDATX7FBZ7DSPPZFD5DPFJM.jpg",
+		});
 	});
 
 	it("must return null if lead_art or basic doesn't have an image", () => {
@@ -175,6 +195,6 @@ describe("when extract an image from a story", () => {
 		const imageUrl =
 			mockStoryPromoItemsGalleryFocalPoint.promo_items.lead_art.promo_items.basic.url;
 
-		expect(url).toEqual(imageUrl);
+		expect(url).toEqual({ _id: "P3V3THIJPVGUBLRIIYWKFHZTKA", type: "image", url: "bar.jpg" });
 	});
 });

--- a/src/utils/get-image-from-ans/getImageFromANS.test.js
+++ b/src/utils/get-image-from-ans/getImageFromANS.test.js
@@ -30,7 +30,7 @@ const mockLeadArtVideo = {
 		},
 	},
 };
-const mockLeadArtVideoNoImage = {
+const mockLeadArtVideoNoImageType = {
 	_id: "ZFGIZMA6LFEUHMOMN4D4CAJXWY",
 	type: "story",
 	version: "0.10.5",
@@ -52,17 +52,12 @@ const mockLeadArtVideoNoImage = {
 			_id: "ba52f779-47be-46b9-8bd5-58dcb4318101",
 			promo_items: {
 				basic: {
-					type: "image",
+					type: "not-image-type",
 					version: "0.5.8",
 					credits: {},
 				},
 			},
 			video_type: "clip",
-			promo_image: {
-				type: "image",
-				version: "0.5.8",
-				credits: {},
-			},
 		},
 	},
 };
@@ -184,8 +179,8 @@ describe("when extract an image from a story", () => {
 		});
 	});
 
-	it("must return null if lead_art or basic doesn't have an image", () => {
-		const url = getImageFromANS(mockLeadArtVideoNoImage);
+	it("must return null if lead_art or basic doesn't have an image type", () => {
+		const url = getImageFromANS(mockLeadArtVideoNoImageType);
 
 		expect(url).toBeNull();
 	});

--- a/src/utils/get-image-from-ans/index.js
+++ b/src/utils/get-image-from-ans/index.js
@@ -7,7 +7,7 @@ const extractImageFromPromo = (promoItem) =>
  *
  * @param storyObject ANS story
  *
- * @return an object with the image URL or null if not found
+ * @return an object with the image URL or null if ans object is not type image
  */
 const getImageFromANS = (storyObject) => {
 	const { promo_items: promoItems } = storyObject || {};

--- a/src/utils/get-image-from-ans/index.js
+++ b/src/utils/get-image-from-ans/index.js
@@ -1,12 +1,13 @@
+// returns an object
 const extractImageFromPromo = (promoItem) =>
-	promoItem?.basic?.type === "image" && promoItem?.basic?.url ? promoItem.basic.url : null;
+	promoItem?.basic?.type === "image" && promoItem?.basic?.url ? promoItem.basic : null;
 
 /**
  * Helper to resolve an image from an story.
  *
  * @param storyObject ANS story
  *
- * @return an string with the image URL or null if not found
+ * @return an object with the image URL or null if not found
  */
 const getImageFromANS = (storyObject) => {
 	const { promo_items: promoItems } = storyObject || {};

--- a/src/utils/get-image-from-ans/index.js
+++ b/src/utils/get-image-from-ans/index.js
@@ -1,6 +1,6 @@
 // returns an object
 const extractImageFromPromo = (promoItem) =>
-	promoItem?.basic?.type === "image" && promoItem?.basic?.url ? promoItem.basic : null;
+	promoItem?.basic?.type === "image" ? promoItem.basic : null;
 
 /**
  * Helper to resolve an image from an story.


### PR DESCRIPTION
## Ticket

- [TMEDIA-942](https://arcpublishing.atlassian.net/browse/TMEDIA-942)

## Description

Return an object not the url 

## Acceptance Criteria

Change [getImageFromANS](https://github.com/WPMedia/arc-themes-components/blob/arc-themes-release-version-2.0.1/src/utils/get-image-from-ans/index.js) function to return all image data for an ANS story.

## Test Steps

- This can be linked with the blocks in the `.env`
- Make sure to update the blocks as well  

Working as expected in commerce for carousel 
<img width="1430" alt="Screen Shot 2022-08-24 at 16 23 20" src="https://user-images.githubusercontent.com/5950956/186526404-699ae051-48fa-4b80-9ee5-52999a412c98.png">

## Author Checklist


- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
