### PR TITLE
Add new util to get image src value from image ANS object

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ import formatURL from "./src/utils/format-url";
 import getImageFromANS from "./src/utils/get-image-from-ans";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
 import useInterval from "./src/utils/hooks/use-interval";
+import imageANSToImageSrc from "./src/utils/image-ans-to-image-src";
 import isServerSide from "./src/utils/is-server-side";
 import serialJoin from "./src/utils/serial-join";
 
@@ -58,6 +59,7 @@ export {
 	HeadingSection,
 	Icon,
 	Image,
+	imageANSToImageSrc,
 	Input,
 	isServerSide,
 	Join,

--- a/src/utils/image-ans-to-image-src/index.js
+++ b/src/utils/image-ans-to-image-src/index.js
@@ -1,0 +1,21 @@
+/**
+ * Helper to take an ANS image object and return an src string
+ *
+ * @param data ANS Image Object
+ *
+ * @return an image string to be used in the src of a image tag
+ */
+const imageANSToImageSrc = (data) => {
+	const { _id: id, url } = data || {};
+
+	if (id && url) {
+		const urlParts = url.split(".");
+		if (urlParts.length !== 1) {
+			return `${id}.${urlParts.pop()}`;
+		}
+	}
+
+	return null;
+};
+
+export default imageANSToImageSrc;

--- a/src/utils/image-ans-to-image-src/index.test.js
+++ b/src/utils/image-ans-to-image-src/index.test.js
@@ -1,0 +1,16 @@
+import imageANSToImageSrc from ".";
+
+describe("imageANSToImageSrc", () => {
+	it("return image src with ext", () => {
+		expect(imageANSToImageSrc({ _id: 123, url: "test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 123, url: "test.test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 321, url: "test.test.jpeg" })).toBe("321.jpeg");
+	});
+
+	it("will return null if incorrect ANS data", () => {
+		expect(imageANSToImageSrc({ _id: 123, url: "testjpg" })).toBe(null);
+		expect(imageANSToImageSrc({ _id: 123 })).toBe(null);
+		expect(imageANSToImageSrc({ url: "testjpg" })).toBe(null);
+		expect(imageANSToImageSrc()).toBe(null);
+	});
+});


### PR DESCRIPTION
## Description

New utility function to take image ANS object and return the image and extension as needed for resizer v2. This is the `_id` and image extension


## Test Steps

Unit tests are written - no need to manually run the code

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
