### PR TITLE
Tmedia 734 gallery set right html

### DIFF
--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -376,9 +376,9 @@ const Carousel = ({
 					{showLabel ? (
 						<p
 							className={`${COMPONENT_CLASS_NAME}__image-counter-label`}
-							dangerouslySetInnerHTML={
-								pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`
-							}
+							dangerouslySetInnerHTML={{
+								__html: pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`,
+							}}
 						/>
 					) : null}
 					{carouselItems.length > 1 && showAdditionalSlideControls ? (

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -348,7 +348,7 @@ const Carousel = ({
 			role="region"
 			aria-roledescription="carousel"
 			style={{
-				"--carousel-slide-width": `${100 / slidesToShowInView}%`,
+				"--carousel-slide-width": `${100 / (slidesToShowInView || slidesToShow)}%`,
 				"--viewable-slides": slidesToShow,
 			}}
 			ref={carouselElement}

--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -374,9 +374,12 @@ const Carousel = ({
 				</div>
 				<div className={`${COMPONENT_CLASS_NAME}__counter-controls-container`}>
 					{showLabel ? (
-						<p className={`${COMPONENT_CLASS_NAME}__image-counter-label`}>
-							{pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`}
-						</p>
+						<p
+							className={`${COMPONENT_CLASS_NAME}__image-counter-label`}
+							dangerouslySetInnerHTML={
+								pageCountPhrase(slide, totalSlides) || `${slide} of ${totalSlides}`
+							}
+						/>
 					) : null}
 					{carouselItems.length > 1 && showAdditionalSlideControls ? (
 						<div className={`${COMPONENT_CLASS_NAME}__additional-controls`}>

--- a/src/components/carousel/index.test.jsx
+++ b/src/components/carousel/index.test.jsx
@@ -579,4 +579,30 @@ describe("Carousel", () => {
 			expect(screen.queryAllByText("Ad Placement")).toHaveLength(1);
 		});
 	});
+
+	it("should render additional label as html", async () => {
+		// divider and play as unicode characters
+		const mockHTML = "&#8227;1 &#47; 2";
+		const { container } = render(
+			<Carousel
+				id="carousel-2"
+				label="Carousel Label"
+				slidesToShow={1}
+				showLabel
+				showAdditionalSlideControls
+				pageCountPhrase={() => mockHTML}
+			>
+				<Carousel.Item label="Slide 1 of 2">
+					<div />
+				</Carousel.Item>
+				<Carousel.Item label="Slide 2 of 2">
+					<div />
+				</Carousel.Item>
+			</Carousel>
+		);
+
+		expect(
+			container.querySelector(".c-carousel__image-counter-label").innerHTML
+		).toMatchInlineSnapshot(`"‣1 / 2"`);
+	});
 });


### PR DESCRIPTION
- See issue in https://github.com/WPMedia/arc-themes-blocks/pull/1491 around inline translations set

todo: 

- [x] write test
- [x] validate this works with my linked branch. -> yep 
![Screen Shot 2022-08-30 at 09 16 45](https://user-images.githubusercontent.com/5950956/187461132-c997228b-65a0-4e54-a60f-414508e649b9.png)


