### PR TITLE
Add new utility for getting promo type

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ import formatURL from "./src/utils/format-url";
 
 // the following are ordered by dependency
 import getImageFromANS from "./src/utils/get-image-from-ans";
+import getPromoType from "./src/utils/get-promo-type";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
 import useInterval from "./src/utils/hooks/use-interval";
 import imageANSToImageSrc from "./src/utils/image-ans-to-image-src";
@@ -53,6 +54,7 @@ export {
 	formatSocialURL,
 	formatURL,
 	getImageFromANS,
+	getPromoType,
 	getVideoFromANS,
 	Grid,
 	Heading,

--- a/src/utils/get-promo-type/index.js
+++ b/src/utils/get-promo-type/index.js
@@ -1,0 +1,26 @@
+function getPromoType(content) {
+	if (!content) {
+		return undefined;
+	}
+
+	let promoType = "";
+
+	switch (content.type) {
+		case "video":
+			promoType = "video";
+			break;
+		case "gallery":
+			promoType = "gallery";
+			break;
+		default:
+			if (content.promo_items?.lead_art?.type) {
+				promoType = getPromoType(content.promo_items.lead_art);
+			} else {
+				promoType = "other";
+			}
+	}
+
+	return promoType;
+}
+
+export default getPromoType;

--- a/src/utils/get-promo-type/index.js
+++ b/src/utils/get-promo-type/index.js
@@ -12,6 +12,9 @@ function getPromoType(content) {
 		case "gallery":
 			promoType = "gallery";
 			break;
+		case "image":
+			promoType = "image";
+			break;
 		default:
 			if (content.promo_items?.lead_art?.type) {
 				promoType = getPromoType(content.promo_items.lead_art);

--- a/src/utils/get-promo-type/index.test.js
+++ b/src/utils/get-promo-type/index.test.js
@@ -10,6 +10,11 @@ const contentTypeGalleryPromo = {
 	type: "story",
 	promo_items: { lead_art: { type: "gallery" } },
 };
+const contentTypeImage = { type: "image" };
+const contentTypeImagePromo = {
+	type: "story",
+	promo_items: { lead_art: { type: "image" } },
+};
 
 describe("should return type of content for labels", () => {
 	it("must return undefined if no parameters received", () => {
@@ -43,6 +48,11 @@ describe("should return type of content for labels", () => {
 		expect(rc).toBe("gallery");
 	});
 
+	it('must return "image" if story type is "image"', () => {
+		const rc = getPromoType(contentTypeImage);
+		expect(rc).toBe("image");
+	});
+
 	it('must return "video" if story type is "story" and promo lead art is "video"', () => {
 		const rc = getPromoType(contentTypeVideoPromo);
 		expect(rc).toBe("video");
@@ -51,5 +61,10 @@ describe("should return type of content for labels", () => {
 	it('must return "gallery" if story type is "story" and promo lead art is "gallery"', () => {
 		const rc = getPromoType(contentTypeGalleryPromo);
 		expect(rc).toBe("gallery");
+	});
+
+	it('must return "image" if story type is "story" and promo lead art is "image"', () => {
+		const rc = getPromoType(contentTypeImagePromo);
+		expect(rc).toBe("image");
 	});
 });

--- a/src/utils/get-promo-type/index.test.js
+++ b/src/utils/get-promo-type/index.test.js
@@ -1,0 +1,55 @@
+import getPromoType from ".";
+
+const contentTypeVideo = { type: "video" };
+const contentTypeVideoPromo = {
+	type: "story",
+	promo_items: { lead_art: { type: "video" } },
+};
+const contentTypeGallery = { type: "gallery" };
+const contentTypeGalleryPromo = {
+	type: "story",
+	promo_items: { lead_art: { type: "gallery" } },
+};
+
+describe("should return type of content for labels", () => {
+	it("must return undefined if no parameters received", () => {
+		let rc = getPromoType();
+		expect(rc).toBeFalsy();
+		rc = getPromoType("");
+		expect(rc).toBeFalsy();
+	});
+
+	it('must return "other" if parameters no match', () => {
+		let rc = getPromoType("foo");
+		expect(rc).toBe("other");
+
+		rc = getPromoType(1);
+		expect(rc).toBe("other");
+
+		rc = getPromoType(true);
+		expect(rc).toBe("other");
+
+		rc = getPromoType({});
+		expect(rc).toBe("other");
+	});
+
+	it('must return "video" if story type is "video"', () => {
+		const rc = getPromoType(contentTypeVideo);
+		expect(rc).toBe("video");
+	});
+
+	it('must return "gallery" if story type is "gallery"', () => {
+		const rc = getPromoType(contentTypeGallery);
+		expect(rc).toBe("gallery");
+	});
+
+	it('must return "video" if story type is "story" and promo lead art is "video"', () => {
+		const rc = getPromoType(contentTypeVideoPromo);
+		expect(rc).toBe("video");
+	});
+
+	it('must return "gallery" if story type is "story" and promo lead art is "gallery"', () => {
+		const rc = getPromoType(contentTypeGalleryPromo);
+		expect(rc).toBe("gallery");
+	});
+});


### PR DESCRIPTION
## Description

Add a utility that was used in multiple blocks (previously known as `discoverPromoType` - moved over and named it `getPromoType`

## Test Steps

The tests should cover everything

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
