### PR TITLE
TMEDIA-967 - Remove top level alias token map

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -6,9 +6,9 @@
 	$global: (
 		"black": #000000,
 		"white": #ffffff,
-		"blue-1": #ebefff,
-		"blue-2": #b0c3f2,
-		"blue-3": #7aa2e5,
+		"blue-1": #f2f5ff,
+		"blue-2": #c5d4fa,
+		"blue-3": #8fb3f0,
 		"blue-4": #4a89d8,
 		"blue-5": #1e78cb,
 		"blue-6": #1458a9,
@@ -16,9 +16,9 @@
 		"blue-8": #062665,
 		"blue-9": #021443,
 		"blue-10": #000721,
-		"red-1": #ff8a8a,
-		"red-2": #e65555,
-		"red-3": #ce2929,
+		"red-1": #ffe4e4,
+		"red-2": #faa7a7,
+		"red-3": #d84e4e,
 		"red-4": #b50505,
 		"red-5": #9c0000,
 		"red-6": #840000,
@@ -26,9 +26,9 @@
 		"red-8": #520000,
 		"red-9": #3a0000,
 		"red-10": #210000,
-		"orange-1": #fa714b,
-		"orange-2": #e24f23,
-		"orange-3": #c93302,
+		"orange-1": #fff4ea,
+		"orange-2": #ffd7b2,
+		"orange-3": #dc6e4a,
 		"orange-4": #b12e00,
 		"orange-5": #982a00,
 		"orange-6": #802500,
@@ -36,9 +36,9 @@
 		"orange-8": #4f1900,
 		"orange-9": #371200,
 		"orange-10": #1f0b00,
-		"green-1": #80d971,
-		"green-2": #57c244,
-		"green-3": #34ab1f,
+		"green-1": #ebfce9,
+		"green-2": #a4e299,
+		"green-3": #5dbe4b,
 		"green-4": #189402,
 		"green-5": #137d00,
 		"green-6": #0f6600,
@@ -46,9 +46,9 @@
 		"green-8": #083800,
 		"green-9": #052100,
 		"green-10": #020a00,
-		"neutral-1": #e6efff,
-		"neutral-2": #c3cfe3,
-		"neutral-3": #a3b0c6,
+		"neutral-1": #eef4ff,
+		"neutral-2": #d3dceb,
+		"neutral-3": #b3bfd2,
 		"neutral-4": #8593aa,
 		"neutral-5": #69778e,
 		"neutral-6": #4f5c71,
@@ -57,39 +57,22 @@
 		"neutral-9": #10151c,
 		"neutral-10": #000000,
 		"spacing-1": 0.25rem,
-		// 4px
 		"spacing-2": 0.5rem,
-		// 8px
 		"spacing-3": 0.75rem,
-		// 12px
 		"spacing-4": 1rem,
-		// 16px
 		"spacing-5": 1.5rem,
-		// 24px
 		"spacing-6": 2rem,
-		// 32px
 		"spacing-7": 2.5rem,
-		// 40px
 		"spacing-8": 3rem,
-		// 48px
 		"spacing-9": 3.5rem,
-		// 56px
 		"spacing-10": 4rem,
-		// 64px
 		"spacing-11": 4.5rem,
-		// 72px
 		"spacing-12": 5rem,
-		// 80px
 		"spacing-13": 5.5rem,
-		// 88px
 		"spacing-14": 6rem,
-		// 96px
 		"spacing-15": 6.5rem,
-		// 104px
 		"spacing-16": 7rem,
-		// 112px
 		"spacing-17": 7.5rem,
-		// 120px
 		"font-weight-1": 100,
 		"font-weight-2": 200,
 		"font-weight-3": 300,
@@ -100,55 +83,26 @@
 		"font-weight-8": 800,
 		"font-weight-9": 900,
 		"font-size-1": 0.625rem,
-		// 10px
 		"font-size-2": 0.75rem,
-		// 12px
 		"font-size-3": 0.875rem,
-		// 14px
 		"font-size-4": 1rem,
-		// 16px
 		"font-size-5": 1.125rem,
-		// 18px
 		"font-size-6": 1.1875rem,
-		// 19px
 		"font-size-7": 1.25rem,
-		// 20px
 		"font-size-8": 1.375rem,
-		// 22px
 		"font-size-9": 1.5rem,
-		// 24px
 		"font-size-10": 1.75rem,
-		// 28px
 		"font-size-11": 2rem,
-		// 32px
 		"font-size-12": 2.25rem,
-		// 36px
 		"font-size-13": 2.56rem,
-		// 41px
 		"font-size-14": 3rem,
-		// 48px
 		"font-size-15": 3.25rem,
-		// 52px
-		"line-height-1": 0.875rem,
-		// 14px
-		"line-height-2": 1rem,
-		// 16px
-		"line-height-3": 1.25rem,
-		// 20px
-		"line-height-4": 1.5rem,
-		// 24px
-		"line-height-5": 2rem,
-		// 32px
-		"line-height-6": 2.125rem,
-		// 34px
-		"line-height-7": 2.5rem,
-		// 40px
-		"line-height-8": 3rem,
-		// 48px
-		"line-height-9": 3.5rem,
-		// 56px
-		"line-height-10": 3.875rem,
-		// 62px
+		"line-height-1": 1,
+		"line-height-2": 1.1,
+		"line-height-3": 1.2,
+		"line-height-4": 1.3,
+		"line-height-5": 1.4,
+		"line-height-6": 1.5,
 		"box-shadow-1": 0px 0px 16px rgba(25, 25, 25, 0.4),
 		"z-index-1": 1,
 		"z-index-2": 10,
@@ -161,60 +115,63 @@
 		"border-style-1": solid,
 		"border-width-1": 1px,
 	),
-	$alias: (
-		// Font families
-		"font-family-primary": "Inter",
-		"font-family-secondary": "Lora",
-		// Colors
-		"color-primary": var(--global-black),
-		"text-color": var(--global-neutral-8),
-		"text-color-subtle": var(--global-neutral-5),
-		"text-color-warning": var(--global-orange-9),
-		"text-color-danger": var(--global-red-9),
-		"text-color-success": var(--global-green-9),
-		"background-color": var(--global-white),
-		"background-color-warning": var(--global-orange-1),
-		"background-color-danger": var(--global-red-1),
-		"background-color-success": var(--global-green-1),
-		"icon-fill-color": var(--global-neutral-8),
-		"icon-fill-color-subtle": var(--global-neutral-5),
-		"border-color": var(--global-neutral-4),
-		"form-background-color": var(--global-white),
-		"form-border-color": var(--global-neutral-5),
-		"form-border-color-primary": var(--global-blue-5),
-		"form-border-color-warning": var(--global-orange-2),
-		"form-border-color-danger": var(--global-red-4),
-		"form-border-color-success": var(--global-green-5),
-		"status-color-success": var(--global-green-5),
-		"status-color-warning": var(--global-orange-5),
-		"status-color-danger": var(--global-red-5),
-		// Border Radius
-		"border-radius": var(--global-border-radius-1),
-		"border-radius-pill": var(--global-border-radius-2),
-		"border-radius-circle": var(--global-border-radius-3),
-		// Typography
-		// body
-		"body-font-weight": var(--global-font-weight-4),
-		"body-font-size": var(--global-font-size-4),
-		"body-line-height": var(--global-line-height-3),
-		// body : small
-		"body-font-weight-small": var(--global-font-weight-4),
-		"body-font-size-small": var(--global-font-size-3),
-		"body-line-height-small": var(--global-line-height-2),
-		// body : tiny
-		"body-font-weight-tiny": var(--global-font-weight-4),
-		"body-font-size-tiny": var(--global-font-size-2),
-		"body-line-height-tiny": var(--global-line-height-1),
-		// Layout
-		"layout-max-width": 1440,
-		"content-max-width": 1216,
-		//
-		// --content-scale-width identifies the inner document width for header and content
-		//
-		"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
-	),
 	$tokens: (
 		default: (
+			alias: (
+				"font-family-primary": "Inter",
+				"font-family-secondary": "Lora",
+				"color-primary": var(--global-black),
+				"text-color": var(--global-neutral-8),
+				"text-color-subtle": var(--global-neutral-5),
+				"background-color": var(--global-white),
+				"icon-fill-color": var(--global-neutral-8),
+				"icon-fill-color-subtle": var(--global-neutral-5),
+				"border-color": var(--global-neutral-4),
+				"form-background-color": var(--global-white),
+				"form-border-color": var(--global-neutral-5),
+				"form-border-color-primary": var(--global-blue-5),
+				"status-color-success": var(--global-green-5),
+				"status-color-success-subtle": var(--global-green-1),
+				"status-color-warning": var(--global-orange-5),
+				"status-color-warning-subtle": var(--global-orange-1),
+				"status-color-danger": var(--global-red-5),
+				"status-color-danger-subtle": var(--global-red-1),
+				"status-color-info": var(--global-blue-5),
+				"status-color-info-subtle": var(--global-blue-1),
+				"border-radius": var(--global-border-radius-1),
+				"border-radius-pill": var(--global-border-radius-2),
+				"border-radius-circle": var(--global-border-radius-3),
+				"heading-level-1-font-size": var(--global-font-size-12),
+				"heading-level-1-line-height": var(--global-line-height-3),
+				"heading-level-1-font-weight": var(--global-font-weight-7),
+				"heading-level-2-font-size": var(--global-font-size-11),
+				"heading-level-2-line-height": var(--global-line-height-4),
+				"heading-level-2-font-weight": var(--global-font-weight-7),
+				"heading-level-3-font-size": var(--global-font-size-10),
+				"heading-level-3-line-height": var(--global-line-height-4),
+				"heading-level-3-font-weight": var(--global-font-weight-7),
+				"heading-level-4-font-size": var(--global-font-size-9),
+				"heading-level-4-line-height": var(--global-line-height-5),
+				"heading-level-4-font-weight": var(--global-font-weight-7),
+				"heading-level-5-font-size": var(--global-font-size-7),
+				"heading-level-5-line-height": var(--global-line-height-5),
+				"heading-level-5-font-weight": var(--global-font-weight-7),
+				"heading-level-6-font-size": var(--global-font-size-5),
+				"heading-level-6-line-height": var(--global-line-height-5),
+				"heading-level-6-font-weight": var(--global-font-weight-7),
+				"body-font-weight": var(--global-font-weight-4),
+				"body-font-size": var(--global-font-size-4),
+				"body-line-height": var(--global-line-height-6),
+				"body-font-weight-small": var(--global-font-weight-4),
+				"body-font-size-small": var(--global-font-size-3),
+				"body-line-height-small": var(--global-line-height-6),
+				"body-font-weight-tiny": var(--global-font-weight-4),
+				"body-font-size-tiny": var(--global-font-size-2),
+				"body-line-height-tiny": var(--global-line-height-6),
+				"layout-max-width": 1440,
+				"content-max-width": 1216,
+				"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
+			),
 			components: (
 				attribution: (
 					color: var(--text-color),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -57,40 +57,22 @@
 		"neutral-9": #10151c,
 		"neutral-10": #000000,
 		"spacing-1": 0.25rem,
-		// 4px
 		"spacing-2": 0.5rem,
-		// 8px
 		"spacing-3": 0.75rem,
-		// 12px
 		"spacing-4": 1rem,
-		// 16px
 		"spacing-5": 1.5rem,
-		// 24px
 		"spacing-6": 2rem,
-		// 32px
 		"spacing-7": 2.5rem,
-		// 40px
 		"spacing-8": 3rem,
-		// 48px
 		"spacing-9": 3.5rem,
-		// 56px
 		"spacing-10": 4rem,
-		// 64px
 		"spacing-11": 4.5rem,
-		// 72px
 		"spacing-12": 5rem,
-		// 80px
 		"spacing-13": 5.5rem,
-		// 88px
 		"spacing-14": 6rem,
-		// 96px
 		"spacing-15": 6.5rem,
-		// 104px
 		"spacing-16": 7rem,
-		// 112px
 		"spacing-17": 7.5rem,
-		// 120px
-		"font-weight-1": 100,
 		"font-weight-2": 200,
 		"font-weight-3": 300,
 		"font-weight-4": 400,
@@ -100,55 +82,26 @@
 		"font-weight-8": 800,
 		"font-weight-9": 900,
 		"font-size-1": 0.625rem,
-		// 10px
 		"font-size-2": 0.75rem,
-		// 12px
 		"font-size-3": 0.875rem,
-		// 14px
 		"font-size-4": 1rem,
-		// 16px
 		"font-size-5": 1.125rem,
-		// 18px
 		"font-size-6": 1.1875rem,
-		// 19px
 		"font-size-7": 1.25rem,
-		// 20px
 		"font-size-8": 1.375rem,
-		// 22px
 		"font-size-9": 1.5rem,
-		// 24px
 		"font-size-10": 1.75rem,
-		// 28px
 		"font-size-11": 2rem,
-		// 32px
 		"font-size-12": 2.25rem,
-		// 36px
 		"font-size-13": 2.56rem,
-		// 41px
 		"font-size-14": 3rem,
-		// 48px
 		"font-size-15": 3.25rem,
-		// 52px
-		"line-height-1": 0.875rem,
-		// 14px
-		"line-height-2": 1rem,
-		// 16px
-		"line-height-3": 1.25rem,
-		// 20px
-		"line-height-4": 1.5rem,
-		// 24px
-		"line-height-5": 2rem,
-		// 32px
-		"line-height-6": 2.125rem,
-		// 34px
-		"line-height-7": 2.5rem,
-		// 40px
-		"line-height-8": 3rem,
-		// 48px
-		"line-height-9": 3.5rem,
-		// 56px
-		"line-height-10": 3.875rem,
-		// 62px
+		"line-height-1": 1,
+		"line-height-2": 1.1,
+		"line-height-3": 1.2,
+		"line-height-4": 1.3,
+		"line-height-5": 1.4,
+		"line-height-6": 1.5,
 		"box-shadow-1": 0px 0px 16px rgba(25, 25, 25, 0.4),
 		"z-index-1": 1,
 		"z-index-2": 10,
@@ -161,56 +114,67 @@
 		"border-style-1": solid,
 		"border-width-1": 1px,
 	),
-	$alias: (
-		// Font families
-		"font-family-primary": "Abel",
-		"font-family-secondary": "Georgia",
-		// Colors
-		"color-primary": var(--global-black),
-		"text-color": var(--global-neutral-8),
-		"text-color-subtle": var(--global-neutral-5),
-		"background-color": var(--global-white),
-		"icon-fill-color": var(--global-neutral-8),
-		"icon-fill-color-subtle": var(--global-neutral-5),
-		"border-color": var(--global-neutral-4),
-		"form-background-color": var(--global-white),
-		"form-border-color": var(--global-neutral-5),
-		"form-border-color-primary": var(--global-blue-5),
-		"status-color-success": var(--global-green-5),
-		"status-color-success-subtle": var(--global-green-1),
-		"status-color-warning": var(--global-orange-5),
-		"status-color-warning-subtle": var(--global-orange-1),
-		"status-color-danger": var(--global-red-5),
-		"status-color-danger-subtle": var(--global-red-1),
-		"status-color-info": var(--global-blue-5),
-		"status-color-info-subtle": var(--global-blue-1),
-		// Border Radius
-		"border-radius": var(--global-border-radius-1),
-		"border-radius-pill": var(--global-border-radius-2),
-		"border-radius-circle": var(--global-border-radius-3),
-		// Typography
-		// body
-		"body-font-weight": var(--global-font-weight-4),
-		"body-font-size": var(--global-font-size-4),
-		"body-line-height": var(--global-line-height-3),
-		// body : small
-		"body-font-weight-small": var(--global-font-weight-4),
-		"body-font-size-small": var(--global-font-size-3),
-		"body-line-height-small": var(--global-line-height-2),
-		// body : tiny
-		"body-font-weight-tiny": var(--global-font-weight-4),
-		"body-font-size-tiny": var(--global-font-size-2),
-		"body-line-height-tiny": var(--global-line-height-1),
-		// Layout
-		"layout-max-width": 1600,
-		"content-max-width": 1440,
-		//
-		// --content-scale-width identifies the inner document width for header and content
-		//
-		"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
-	),
 	$tokens: (
 		default: (
+			alias: (
+				"font-family-primary": "Abel",
+				"font-family-secondary": "Georgia",
+				"color-primary": var(--global-black),
+				"color-primary-hover": var(--global-neutral-7),
+				"text-color": var(--global-neutral-8),
+				"text-color-subtle": var(--global-neutral-5),
+				"background-color": var(--global-white),
+				"icon-fill-color": var(--global-neutral-8),
+				"icon-fill-color-subtle": var(--global-neutral-4),
+				"border-color": var(--global-neutral-4),
+				"form-background-color": var(--global-white),
+				"form-border-color": var(--global-neutral-5),
+				"form-border-color-primary": var(--global-blue-5),
+				"status-color-success": var(--global-green-5),
+				"status-color-success-subtle": var(--global-green-1),
+				"status-color-warning": var(--global-orange-5),
+				"status-color-warning-subtle": var(--global-orange-1),
+				"status-color-danger": var(--global-red-5),
+				"status-color-danger-subtle": var(--global-red-1),
+				"status-color-info": var(--global-blue-5),
+				"status-color-info-subtle": var(--global-blue-1),
+				"border-radius": var(--global-border-radius-1),
+				"border-radius-pill": var(--global-border-radius-2),
+				"border-radius-circle": var(--global-border-radius-3),
+				"heading-level-1-font-size": var(--global-font-size-12),
+				"heading-level-1-line-height": var(--global-line-height-3),
+				"heading-level-1-font-weight": var(--global-font-weight-7),
+				"heading-level-2-font-size": var(--global-font-size-11),
+				"heading-level-2-line-height": var(--global-line-height-4),
+				"heading-level-2-font-weight": var(--global-font-weight-7),
+				"heading-level-3-font-size": var(--global-font-size-10),
+				"heading-level-3-line-height": var(--global-line-height-4),
+				"heading-level-3-font-weight": var(--global-font-weight-7),
+				"heading-level-4-font-size": var(--global-font-size-9),
+				"heading-level-4-line-height": var(--global-line-height-5),
+				"heading-level-4-font-weight": var(--global-font-weight-7),
+				"heading-level-5-font-size": var(--global-font-size-7),
+				"heading-level-5-line-height": var(--global-line-height-5),
+				"heading-level-5-font-weight": var(--global-font-weight-7),
+				"heading-level-6-font-size": var(--global-font-size-5),
+				"heading-level-6-line-height": var(--global-line-height-5),
+				"heading-level-6-font-weight": var(--global-font-weight-7),
+				"body-font-weight": var(--global-font-weight-4),
+				"body-font-size": var(--global-font-size-4),
+				"body-line-height": var(--global-line-height-6),
+				"body-font-weight-small": var(--global-font-weight-4),
+				"body-font-size-small": var(--global-font-size-3),
+				"body-line-height-small": var(--global-line-height-6),
+				"body-font-weight-tiny": var(--global-font-weight-4),
+				"body-font-size-tiny": var(--global-font-size-2),
+				"body-line-height-tiny": var(--global-line-height-6),
+				"layout-max-width": 1600,
+				"content-max-width": 1440,
+				"content-scale-width": calc(var(--content-max-width) / var(--layout-max-width) * 100%),
+				"header-nav-chain-height": 56px,
+				"header-nav-chain-height-scrolled": 56px,
+				"header-nav-chain-overlay-background-color": rgba(25, 25, 25, 0.5),
+			),
 			components: (
 				attribution: (
 					color: var(--text-color),

--- a/src/scss/index.test.scss
+++ b/src/scss/index.test.scss
@@ -67,7 +67,6 @@ $tokens: (
 );
 
 @use "root" with (
-	$alias: (),
 	$breakpoints: (
 		default: "min-width: 0",
 		tablet: "min-width: 20rem",

--- a/src/scss/root/_index.scss
+++ b/src/scss/root/_index.scss
@@ -8,7 +8,6 @@
 //
 // Variables
 //
-$alias: () !default;
 $breakpoints: (
 	default: "min-width: 0",
 ) !default;
@@ -177,9 +176,6 @@ $component-map: get-all-component-definitions($tokens, $breakpoints);
 :root {
 	@each $name, $value in $global {
 		--global-#{$name}: #{maintain-quotes($value)};
-	}
-	@each $name, $value in $alias {
-		--#{$name}: #{maintain-quotes($value)};
 	}
 }
 


### PR DESCRIPTION
## Ticket

- [TMEDIA-697](https://arcpublishing.atlassian.net/browse/TMEDIA-697)

## Description

Move top level alias token map to be inside `$tokens.default`. This is a change to help make things cleaner when we start to utilise JSON files to handle defining styles

Alias tokens where copied from their respective feature pack Sass files for each theme

**NOTE** This is going to require all 2.0.3 branches for themes to be updated to match these changes, Feature Pack, Blocks and Components

Dependent PRs >
Blocks - https://github.com/WPMedia/arc-themes-blocks/pull/1547
Feature Pack - 
News - https://github.com/WPMedia/arc-themes-feature-pack/pull/362
Commerce - https://github.com/WPMedia/arc-themes-feature-pack/pull/363


## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
