### PR TITLE
THEMES-806 - Fix window resize logic to set position correctly

### DIFF
--- a/src/components/carousel/index.jsx
+++ b/src/components/carousel/index.jsx
@@ -181,19 +181,14 @@ const Carousel = ({
 
 	useEffect(() => {
 		const resizeFn = () => {
-			if (
-				slidesToShowInView === 0 ||
-				getSlidesToShowFromDom(carouselElement.current) === slidesToShowInView
-			) {
-				return;
-			}
-			setSlidesToShowInView(getSlidesToShowFromDom(carouselElement.current));
-			setSlide(getSlidesToShowFromDom(carouselElement.current));
-			setPosition(0);
+			const slideOffset =
+				carouselElement.current.querySelector(`.c-carousel__slide:nth-of-type(${slide})`)
+					?.offsetLeft || 0;
+			setPosition(-slideOffset);
 		};
 		window.addEventListener("resize", resizeFn, false);
 		return () => window.removeEventListener("resize", resizeFn, false);
-	}, [carouselElement, slidesToShowInView]);
+	});
 
 	const childItems = Children.toArray(subComponents);
 


### PR DESCRIPTION
## Ticket

- [THEMES-806](https://arcpublishing.atlassian.net/browse/THEMES-806)

## Description

Fix issue in carousel resize handler that was not resetting the slide offset when window viewport changes

## Test Steps

1. Checkout branch - `git checkout THEMES-806`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Load carousel story - http://localhost:60003/iframe.html?id=components-carousel--show-with-label-and-full-screen-toggle-with-multiple-slides&args=&viewMode=story
5. Click through to the second or third image
6. Resize your window and verify carousel adjusts to keep image in correct position
7. Click the Full Screen button and then click the Minimise button
8. Verify the carousel renders correct

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
