### PR TITLE
Ignore images from chromatic

### DIFF
--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -1,4 +1,5 @@
-export default jest.fn(() => ({
-	RESIZER_APP_VERSION: "",
-	RESIZER_URL: "https://arc/resizer/v2/",
-}));
+const RESIZER_APP_VERSION = 2;
+
+const RESIZER_URL = "http://url.com/";
+
+export { RESIZER_APP_VERSION, RESIZER_URL };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -76,6 +76,7 @@ const Image = ({
 	return (
 		<img
 			{...rest}
+			data-chromatic="ignore"
 			alt={alt}
 			className={componentClassNames}
 			loading={loading}

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -276,4 +276,25 @@ describe("Image", () => {
 		const element = screen.getByRole("img");
 		expect(element).toHaveAttribute("sizes", "(min-width: 600px) 50vw");
 	});
+
+	it("uses ansImage prop for data", () => {
+		render(
+			<Image
+				ansImage={{
+					_id: 123,
+					url: "test-image.jpg",
+					auth: {
+						2: "secret",
+					},
+				}}
+				resizerURL="https://resizer.example.com/"
+				resizedOptions={{ filter: 70, quality: 50 }}
+			/>
+		);
+		const element = screen.getByRole("img");
+		expect(element).toHaveAttribute(
+			"src",
+			"https://resizer.example.com/123.jpg?filter=70&quality=50&auth=secret"
+		);
+	});
 });


### PR DESCRIPTION
Adding chromatic `data-chromatic="ignore"` to image component to reduce false positives with blocks chromatic runs