### PR TITLE
Themes 858

### DIFF
--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -18,21 +18,28 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
+	const embedMarkupWithAspectRatio =
+		aspectRatio === "16:9" || !aspectRatio
+			? embedMarkup
+			: embedMarkup?.replace("0.562", aspectRatio.split(":")[1] / aspectRatio.split(":")[0]);
+
+	const aspectRatioFormatted = aspectRatio ? aspectRatio.replace(":", "/") : "16/9";
+
 	return (
 		<div className={`${COMPONENT_CLASS_NAME}__frame`}>
 			<div
 				{...rest}
 				className={containerClassNames}
 				style={{
-					"--aspect-ratio": aspectRatio,
+					"--aspect-ratio": aspectRatioFormatted,
 					"--height": viewportPercentage,
 				}}
 			>
 				{shouldRenderVideoContent ? (
-					<EmbedContainer markup={embedMarkup}>
+					<EmbedContainer markup={embedMarkupWithAspectRatio}>
 						<div
 							dangerouslySetInnerHTML={{
-								__html: embedMarkup,
+								__html: embedMarkupWithAspectRatio,
 							}}
 						/>
 					</EmbedContainer>
@@ -46,7 +53,7 @@ Video.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The aspect ratio of the video */
-	aspectRatio: PropTypes.number,
+	aspectRatio: PropTypes.oneOf(["16:9", "3:2", "4:3"]),
 	/* The vertical percentage of the viewport takes up */
 	viewportPercentage: PropTypes.number,
 };

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -21,7 +21,7 @@ const Feature = () => {
 	const embedMarkup =
 		'<div class="powa" id="powa-ezzy" data-org="corecomponents" data-env="prod" data-uuid="ezzy" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>';
 
-	return <Video embedMarkup={embedMarkup} aspectRatio={16 / 9} viewportPercentage={50} />;
+	return <Video embedMarkup={embedMarkup} aspectRatio="16:9" viewportPercentage={50} />;
 };
 ```
 
@@ -37,7 +37,7 @@ const Feature = () => {
 	<Story name="Video Half Vertical Viewport Loading">
 		<Video
 			viewportPercentage={50}
-			aspectRatio={1 / 0.562}
+			aspectRatio="16:9"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -51,7 +51,7 @@ const Feature = () => {
 	<Story name="Video Full Vertical Viewport Loading">
 		<Video
 			viewportPercentage={100}
-			aspectRatio={1 / 0.562}
+			aspectRatio="16:9"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -65,7 +65,7 @@ const Feature = () => {
 	<Story name="Video One Third Vertical Viewport Loading">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={1 / 0.562}
+			aspectRatio="16:9"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -79,14 +79,14 @@ const Feature = () => {
 	<Story name="Two videos, different aspect ratios">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={4 / 3}
+			aspectRatio="4:3"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.75" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
 		/>
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio={1 / 0.562}
+			aspectRatio="16:9"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}

--- a/src/components/video/index.test.jsx
+++ b/src/components/video/index.test.jsx
@@ -24,7 +24,7 @@ describe("Video", () => {
 	});
 
 	it("should render container with aspect ratio", () => {
-		const { container } = render(<Video aspectRatio={"4:3"} />);
+		const { container } = render(<Video aspectRatio="4:3" />);
 		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--aspect-ratio: 4/3");
 	});
 
@@ -50,7 +50,7 @@ describe("Video", () => {
 		// mock window powa boot function to mimick powa
 		window.powaBoot = jest.fn();
 		const { container } = render(
-			<Video aspectRatio={"4:3"} embedMarkup="<div class='powa' data-aspect-ratio='0.562'/>" />
+			<Video aspectRatio="4:3" embedMarkup="<div class='powa' data-aspect-ratio='0.562'/>" />
 		);
 		expect(window.powaBoot).toHaveBeenCalled();
 		expect(container.querySelector(".powa")).not.toBeNull();

--- a/src/components/video/index.test.jsx
+++ b/src/components/video/index.test.jsx
@@ -24,10 +24,13 @@ describe("Video", () => {
 	});
 
 	it("should render container with aspect ratio", () => {
-		const { container } = render(<Video aspectRatio={16 / 9} />);
-		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle(
-			"--aspect-ratio: 1.7777777777777777"
-		);
+		const { container } = render(<Video aspectRatio={"4:3"} />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--aspect-ratio: 4/3");
+	});
+
+	it("should render container with aspect ratio of 16:9 if none is provided", () => {
+		const { container } = render(<Video />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--aspect-ratio: 16/9");
 	});
 
 	it("should render container with vertical viewport percentage", () => {
@@ -41,5 +44,16 @@ describe("Video", () => {
 		const { container } = render(<Video embedMarkup="<div class='powa' />" />);
 		expect(window.powaBoot).toHaveBeenCalled();
 		expect(container.querySelector(".powa")).not.toBeNull();
+	});
+
+	it("should modify the embed markup aspect ratio if not equal to 16:9 and render markup if not empty", () => {
+		// mock window powa boot function to mimick powa
+		window.powaBoot = jest.fn();
+		const { container } = render(
+			<Video aspectRatio={"4:3"} embedMarkup="<div class='powa' data-aspect-ratio='0.562'/>" />
+		);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(".powa")).not.toBeNull();
+		expect(container.querySelector(".powa")).toHaveAttribute("data-aspect-ratio", "0.75");
 	});
 });


### PR DESCRIPTION
## Ticket

- [THEMES-858](https://arcpublishing.atlassian.net/browse/THEMES-858)

## Description

**NOTE** This update goes with [PR 1603](https://github.com/WPMedia/arc-themes-blocks/pull/1603), which updates the Top Table list to pass the aspect ratio props into the video component.

These updates are intended to allow the Top Table List, XL Promo, and LG Promo blocks to have play-in-place video thumbnails that use the aspect ratio specified in custom fields. Those blocks will need to be modified to pass the aspect ratio into the video component as a prop. With this update, once the aspect ratio is passed in, the video thumbnails will render with the correct aspect ratio if the "play video in place" box has been checked.

Changes made:
- Updated Video Component to accept aspectRatio props for play-in-place videos 
- Reformatted the aspectRatio and embedMarkup props to function correctly in the powa-player
- Updated aspectRatio PropTypes to match PropTypes from the [Top Table List Block](https://github.com/WPMedia/arc-themes-blocks/blob/arc-themes-release-version-2.0.3/blocks/top-table-list-block/features/top-table-list/shared/imageRatioCustomField.js)
- Updated Tests to account for different aspectRatio props
- Updated stories.mdx to use ratio props instead of fraction props

## Acceptance Criteria

Aspect ratio from the custom field in Large and Extra Large story settings sections are used for the video thumbnail if the "Play video in place" box has been checked

## Test Steps

1. Checkout branch - `git checkout themes-858`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed relevant documentation has been updated/added.
- [ ] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-858]: https://arcpublishing.atlassian.net/browse/THEMES-858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ