### PR TITLE
THEMES-914: Fix for missing images without IDs

### DIFF
--- a/src/utils/get-image-from-ans/index.js
+++ b/src/utils/get-image-from-ans/index.js
@@ -1,6 +1,6 @@
 // returns an object
 const extractImageFromPromo = (promoItem) =>
-	promoItem?.basic?.type === "image" ? promoItem.basic : null;
+	promoItem?.basic?.type === "image" && promoItem?.basic?.url ? promoItem.basic : null;
 
 /**
  * Helper to resolve an image from an story.

--- a/src/utils/image-ans-to-image-src/index.js
+++ b/src/utils/image-ans-to-image-src/index.js
@@ -7,15 +7,15 @@
  */
 const imageANSToImageSrc = (data) => {
 	const { _id: id, auth, url } = data || {};
-
-	if (id && url) {
-		const urlParts = url.split(".");
-		if (urlParts.length !== 1) {
-			return `${id}.${urlParts.pop()}`;
+	if (url) {
+		if (id) {
+			const urlParts = url.split(".");
+			if (urlParts.length !== 1) {
+				return `${id}.${urlParts.pop()}`;
+			}
+		} else if (auth) {
+			return encodeURI(url);
 		}
-	}
-	if (auth) {
-		return encodeURI(url);
 	}
 	return null;
 };

--- a/src/utils/image-ans-to-image-src/index.js
+++ b/src/utils/image-ans-to-image-src/index.js
@@ -6,7 +6,7 @@
  * @return an image string to be used in the src of a image tag
  */
 const imageANSToImageSrc = (data) => {
-	const { _id: id, url } = data || {};
+	const { _id: id, auth, url } = data || {};
 
 	if (id && url) {
 		const urlParts = url.split(".");
@@ -14,7 +14,9 @@ const imageANSToImageSrc = (data) => {
 			return `${id}.${urlParts.pop()}`;
 		}
 	}
-
+	if (auth) {
+		return encodeURI(url);
+	}
 	return null;
 };
 

--- a/src/utils/image-ans-to-image-src/index.test.js
+++ b/src/utils/image-ans-to-image-src/index.test.js
@@ -7,6 +7,12 @@ describe("imageANSToImageSrc", () => {
 		expect(imageANSToImageSrc({ _id: 321, url: "test.test.jpeg" })).toBe("321.jpeg");
 	});
 
+	it("return image src as encoded url when no _id but an auth exists", () => {
+		expect(imageANSToImageSrc({ url: "http://image.com/test.jpg", auth: { 1: "123" } })).toBe(
+			"http://image.com/test.jpg"
+		);
+	});
+
 	it("will return null if incorrect ANS data", () => {
 		expect(imageANSToImageSrc({ _id: 123, url: "testjpg" })).toBe(null);
 		expect(imageANSToImageSrc({ _id: 123 })).toBe(null);


### PR DESCRIPTION
## Ticket

- [THEMES-914](https://arcpublishing.atlassian.net/browse/THEMES-914)

## Description

This change fixes some of the images that not have an auth without an _id.

## Acceptance Criteria

Resizer Urls from third party sites will return an encoded url as the src.

## Test Steps

1. Checkout branch - `git checkout themes-914`
2. Update dependencies - `npm i`
3. Run Test `npm run test -- -t 'return image src as encoded url when no _id but an auth exists'`
4. ensure test success

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-914]: https://arcpublishing.atlassian.net/browse/THEMES-914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ