### PR TITLE
THEMES-1039: Error handler for fetch content sources.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ import formatURL from "./src/utils/format-url";
 import getImageFromANS from "./src/utils/get-image-from-ans";
 import getPromoType from "./src/utils/get-promo-type";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
+import handleFetchError from "./src/utils/handle-fetch-error";
 import useInterval from "./src/utils/hooks/use-interval";
 import usePhrases from "./src/utils/hooks/use-phrases";
 import imageANSToImageSrc from "./src/utils/image-ans-to-image-src";
@@ -63,6 +64,7 @@ export {
 	getPromoType,
 	getVideoFromANS,
 	Grid,
+	handleFetchError,
 	Heading,
 	HeadingSection,
 	Icon,

--- a/src/utils/handle-fetch-error/index.js
+++ b/src/utils/handle-fetch-error/index.js
@@ -1,0 +1,13 @@
+const handleFetchError = (error) => {
+	if (error?.response) {
+		throw new Error(
+			`The response from the server was an error with the status code ${error?.response?.status}.`
+		);
+	} else if (error?.request) {
+		throw new Error("The request to the server failed with no response.");
+	} else {
+		throw new Error("An error occured creating the request.");
+	}
+};
+
+export default handleFetchError;

--- a/src/utils/handle-fetch-error/index.test.js
+++ b/src/utils/handle-fetch-error/index.test.js
@@ -1,0 +1,29 @@
+import handleFetchError from ".";
+
+describe("handleFetchError()", () => {
+	it("handles errors with the response", () => {
+		try {
+			handleFetchError({ response: { status: "404" } });
+		} catch (e) {
+			expect(e.message).toEqual(
+				"The response from the server was an error with the status code 404."
+			);
+		}
+	});
+
+	it("handles errors with the request", () => {
+		try {
+			handleFetchError({ request: {} });
+		} catch (e) {
+			expect(e.message).toEqual("The request to the server failed with no response.");
+		}
+	});
+
+	it("handles errors creating the request", () => {
+		try {
+			handleFetchError({});
+		} catch (e) {
+			expect(e.message).toEqual("An error occured creating the request.");
+		}
+	});
+});


### PR DESCRIPTION
## Ticket

- [THEMES-1039](https://arcpublishing.atlassian.net/browse/THEMES-1039)

## Description

This PR adds a utility function to handle errors for fetch content sources in `arc-themes-blocks`.

## Acceptance Criteria

- GIVEN I am a PB Admin, WHEN I misconfigure a block using the above content sources, THEN: 
  - Confirm all content sources using axios fetch and apply this change to all 
  - The content source error is “Internal Server Error” 
  - The full axios objects are blocked from being exposed in the browser
  - Update the templates for the generator 

## Test Steps

1. Checkout branch - `git checkout THEMES-1039`
2. Update dependencies - `npm i`
3. Run unit tests `npm run test`
4. The tests for `handleFetchError` should pass.
5. See `arc-themes-blocks` PR: https://github.com/WPMedia/arc-themes-blocks/pull/1641

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1039]: https://arcpublishing.atlassian.net/browse/THEMES-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ