### PR TITLE
THEMES-1073: Add localizeDate and localizeDateTime utilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ import useInterval from "./src/utils/hooks/use-interval";
 import usePhrases from "./src/utils/hooks/use-phrases";
 import imageANSToImageSrc from "./src/utils/image-ans-to-image-src";
 import isServerSide from "./src/utils/is-server-side";
+import { localizeDate, localizeDateTime } from "./src/utils/localize-date";
 import serialJoin from "./src/utils/serial-join";
 import signImagesInANSObject from "./src/utils/sign-images-in-ans-object";
 
@@ -74,6 +75,8 @@ export {
 	isServerSide,
 	Join,
 	Link,
+	localizeDate,
+	localizeDateTime,
 	MediaItem,
 	Overline,
 	Paragraph,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5005,6 +5005,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@wpmedia/timezone": {
+      "version": "1.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@WPMedia/timezone/1.1.1/bdcfc9fe46beecfe4ec5e5cf71095dae7e2588f3",
+      "integrity": "sha512-nN6M2q8cyJELhihJ65t4CVFWr7QgZSnO+aAEXVFdh/k9RpQJd7EtGVLjZyd8HzAFwhiGv+O4Iz7nclbOnNXEWg=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "stylelint-no-unsupported-browser-features": "^5.0.2"
   },
   "dependencies": {
+    "@wpmedia/timezone": "^1.1.1",
     "react-oembed-container": "^1.0.1",
     "react-swipeable": "^6.2.1"
   }

--- a/src/utils/localize-date/helper.js
+++ b/src/utils/localize-date/helper.js
@@ -1,0 +1,48 @@
+// tz docs https://bigeasy.github.io/timezone/
+const tz = require("@wpmedia/timezone")(
+	require("@wpmedia/timezone/zones"),
+	require("@wpmedia/timezone/locales")
+);
+
+function localizeDateHelper(date, targetDateFormat, language, timeZone) {
+	let locale = null;
+	switch (language) {
+		case "sv":
+			locale = "sv_SE";
+			break;
+		case "fr":
+			locale = "fr_FR";
+			break;
+		case "no":
+			locale = "nb_NO";
+			break;
+		case "de":
+			locale = "de_DE";
+			break;
+		case "es":
+			locale = "es_ES";
+			break;
+		case "ja":
+			locale = "ja_JP";
+			break;
+		case "ko":
+			locale = "ko_KR";
+			break;
+		case "pt":
+			locale = "pt_PT";
+			break;
+		case "en":
+			locale = "en_US";
+			break;
+		default:
+			locale = language;
+	}
+
+	// Convert to UTC date
+	// utc time is not region-specific
+	const utc = tz(date);
+
+	return tz(utc, locale, timeZone, targetDateFormat);
+}
+
+export default localizeDateHelper;

--- a/src/utils/localize-date/index.js
+++ b/src/utils/localize-date/index.js
@@ -1,0 +1,47 @@
+import localizeDateHelper from "./helper";
+import isValidDateFormatString from "./valid-date-format";
+
+const DATE_FORMAT_FALLBACK = "%B %d, %Y";
+const DATE_TIME_FORMAT_FALLBACK = "%B %d, %Y at %l:%M%p %Z";
+
+const localizeDate = (
+	date,
+	dateFormat = DATE_FORMAT_FALLBACK,
+	language = "en",
+	timeZone = "America/New_York"
+) => {
+	if (!date) return "";
+
+	let validDateFormat = dateFormat;
+
+	if (!isValidDateFormatString(dateFormat)) {
+		validDateFormat = DATE_FORMAT_FALLBACK;
+	}
+
+	return localizeDateHelper(date, validDateFormat, language, timeZone);
+};
+
+const localizeDateTime = (
+	date,
+	dateFormat = DATE_TIME_FORMAT_FALLBACK,
+	language = "en",
+	timeZone = "America/New_York"
+) => {
+	if (!date) return "";
+
+	let validDateFormat = dateFormat;
+
+	if (!isValidDateFormatString(dateFormat)) {
+		validDateFormat = DATE_TIME_FORMAT_FALLBACK;
+	}
+
+	return localizeDateHelper(
+		date,
+		// default includes time (see dateTimeFormat property)
+		validDateFormat,
+		language,
+		timeZone
+	);
+};
+
+export { localizeDate, localizeDateTime };

--- a/src/utils/localize-date/index.test.js
+++ b/src/utils/localize-date/index.test.js
@@ -1,52 +1,116 @@
-import localizeDateHelper from "./helper";
+import { localizeDate, localizeDateTime } from ".";
 
-// supported locale and timezone if no blocks.json found
-it("returns us east expected output with at", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y at %l:%M %P %Z", "en", "America/New_York")
-	).toEqual("January 01, 2000 at  8:00 pm EST");
+describe("localizeDate()", () => {
+	// supported locale and timezone if no blocks.json found
+	it("returns us east expected output with at", () => {
+		expect(localizeDate("2000-01-02", "%B %d, %Y", "en", "America/New_York")).toEqual(
+			"January 01, 2000"
+		);
+	});
+
+	// unsupported locale and timezone if no blocks.json found
+	it("returns American english language and utc date for timezone not found", () => {
+		expect(localizeDate("2000-01-02 01:00", "%B %d, %Y", "wrong_LANG", "Incorrect/Zone")).toEqual(
+			"January 02, 2000"
+		);
+	});
+
+	it("returns empty when no date is passed in", () => {
+		expect(localizeDate()).toEqual("");
+	});
+
+	it("uses the default format if invalid", () => {
+		expect(localizeDate("2000-01-02", "    ")).toEqual("January 01, 2000");
+	});
 });
 
-// unsupported locale and timezone if no blocks.json found
-it("returns American english language and utc date for timezone not found", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "wrong_LANG", "Incorrect/Zone")
-	).toEqual("January 02, 2000  1:00 am UTC");
-});
+describe("lcoalizeDateTime()", () => {
+	// supported locale and timezone if no blocks.json found
+	it("returns us east expected output with at", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M %P %Z", "en", "America/New_York")
+		).toEqual("January 01, 2000 at  8:00 pm EST");
+	});
 
-// supported locale if no blocks.json found
-// unsupported timezone if no blocks.json found
-it("returns correct Korean language for locale ko but falls back to UTC", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "ko", "Incorrect/Zone")
-	).toEqual("1월 02, 2000  1:00 오전 UTC");
-});
+	// unsupported locale and timezone if no blocks.json found
+	it("returns American english language and utc date for timezone not found", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "wrong_LANG", "Incorrect/Zone")
+		).toEqual("January 02, 2000  1:00 am UTC");
+	});
 
-// supported timezone by default if no blocks.json found
-// supported language en to show am/pm
-// Pacific/Auckland GMT+13
-it("supports Auckland timezone", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Pacific/Auckland")
-	).toEqual("January 02, 2000  2:00 pm NZDT");
-});
+	// supported locale if no blocks.json found
+	// unsupported timezone if no blocks.json found
+	it("returns correct Korean language for locale ko but falls back to UTC", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "ko", "Incorrect/Zone")
+		).toEqual("1월 02, 2000  1:00 오전 UTC");
+	});
 
-// supported timezone by default if no blocks.json found
-// paris (GMT+1)
-it("supports Paris timezone", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Europe/Paris")
-	).toEqual("January 02, 2000  2:00 am CET");
-});
+	// supported timezone by default if no blocks.json found
+	// supported language en to show am/pm
+	// Pacific/Auckland GMT+13
+	it("supports Auckland timezone", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Pacific/Auckland")
+		).toEqual("January 02, 2000  2:00 pm NZDT");
+	});
 
-it("handles french meridiems", () => {
-	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "fr", "Europe/Paris")
-	).toEqual("janvier 02, 2000  2:00 am CET");
-});
+	// supported timezone by default if no blocks.json found
+	// paris (GMT+1)
+	it("supports Paris timezone", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Europe/Paris")
+		).toEqual("January 02, 2000  2:00 am CET");
+	});
 
-it("handles spanish meridiems", () => {
-	expect(
-		localizeDateHelper("2000-01-02 13:00", "%B %d, %Y %l:%M %P %Z", "es", "Europe/Paris")
-	).toEqual("enero 02, 2000  2:00 pm CET");
+	it("handles french meridiems", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "fr", "Europe/Paris")
+		).toEqual("janvier 02, 2000  2:00 am CET");
+	});
+
+	it("handles spanish meridiems", () => {
+		expect(
+			localizeDateTime("2000-01-02 13:00", "%B %d, %Y %l:%M %P %Z", "es", "Europe/Paris")
+		).toEqual("enero 02, 2000  2:00 pm CET");
+	});
+
+	it("returns empty when no date is passed in", () => {
+		expect(localizeDateTime()).toEqual("");
+	});
+
+	it("uses the default format if invalid", () => {
+		expect(localizeDateTime("2000-01-02 01:00", "   ")).toEqual("January 01, 2000 at  8:00PM EST");
+	});
+
+	it("returns Swedish locale", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M%p %Z", "sv", "America/New_York")
+		).toEqual("januari 01, 2000 at  8:00PM EST");
+	});
+
+	it("returns Norwegian locale", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M%p %Z", "no", "America/New_York")
+		).toEqual("januar 01, 2000 at  8:00PM EST");
+	});
+
+	it("returns German locale", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M%p %Z", "de", "America/New_York")
+		).toEqual("Januar 01, 2000 at  8:00PM EST");
+	});
+
+	it("returns Japanese locale", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M%p %Z", "ja", "America/New_York")
+		).toEqual("1月 01, 2000 at  8:00午後 EST");
+	});
+
+	it("returns Portuguese locale", () => {
+		expect(
+			localizeDateTime("2000-01-02 01:00", "%B %d, %Y at %l:%M%p %Z", "pt", "America/New_York")
+		).toEqual("Janeiro 01, 2000 at  8:00PM EST");
+	});
 });

--- a/src/utils/localize-date/index.test.js
+++ b/src/utils/localize-date/index.test.js
@@ -4,29 +4,22 @@ import localizeDateHelper from "./helper";
 it("returns us east expected output with at", () => {
 	expect(
 		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y at %l:%M %P %Z", "en", "America/New_York")
-	).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
+	).toEqual("January 01, 2000 at  8:00 pm EST");
 });
 
 // unsupported locale and timezone if no blocks.json found
 it("returns American english language and utc date for timezone not found", () => {
 	expect(
-		localizeDateHelper(
-			"2000-01-02 01:00",
-			"%B %d, %Y %l:%M %P %Z",
-			"hi_IN",
-			// india has half-hour timezone +05:30
-			// india standard time
-			"Asia/Kolkata"
-		)
-	).toMatchInlineSnapshot('"January 02, 2000  1:00 am UTC"');
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "wrong_LANG", "Incorrect/Zone")
+	).toEqual("January 02, 2000  1:00 am UTC");
 });
 
 // supported locale if no blocks.json found
 // unsupported timezone if no blocks.json found
 it("returns correct Korean language for locale ko but falls back to UTC", () => {
 	expect(
-		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "ko", "Asia/Seoul")
-	).toMatchInlineSnapshot('"1월 02, 2000  1:00 오전 UTC"');
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "ko", "Incorrect/Zone")
+	).toEqual("1월 02, 2000  1:00 오전 UTC");
 });
 
 // supported timezone by default if no blocks.json found
@@ -35,7 +28,7 @@ it("returns correct Korean language for locale ko but falls back to UTC", () => 
 it("supports Auckland timezone", () => {
 	expect(
 		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Pacific/Auckland")
-	).toMatchInlineSnapshot('"January 02, 2000  2:00 pm NZDT"');
+	).toEqual("January 02, 2000  2:00 pm NZDT");
 });
 
 // supported timezone by default if no blocks.json found
@@ -43,17 +36,17 @@ it("supports Auckland timezone", () => {
 it("supports Paris timezone", () => {
 	expect(
 		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Europe/Paris")
-	).toMatchInlineSnapshot('"January 02, 2000  2:00 am CET"');
+	).toEqual("January 02, 2000  2:00 am CET");
 });
 
 it("handles french meridiems", () => {
 	expect(
 		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "fr", "Europe/Paris")
-	).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
+	).toEqual("janvier 02, 2000  2:00 am CET");
 });
 
 it("handles spanish meridiems", () => {
 	expect(
 		localizeDateHelper("2000-01-02 13:00", "%B %d, %Y %l:%M %P %Z", "es", "Europe/Paris")
-	).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
+	).toEqual("enero 02, 2000  2:00 pm CET");
 });

--- a/src/utils/localize-date/index.test.js
+++ b/src/utils/localize-date/index.test.js
@@ -1,0 +1,59 @@
+import localizeDateHelper from "./helper";
+
+// supported locale and timezone if no blocks.json found
+it("returns us east expected output with at", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y at %l:%M %P %Z", "en", "America/New_York")
+	).toMatchInlineSnapshot('"January 01, 2000 at  8:00 pm EST"');
+});
+
+// unsupported locale and timezone if no blocks.json found
+it("returns American english language and utc date for timezone not found", () => {
+	expect(
+		localizeDateHelper(
+			"2000-01-02 01:00",
+			"%B %d, %Y %l:%M %P %Z",
+			"hi_IN",
+			// india has half-hour timezone +05:30
+			// india standard time
+			"Asia/Kolkata"
+		)
+	).toMatchInlineSnapshot('"January 02, 2000  1:00 am UTC"');
+});
+
+// supported locale if no blocks.json found
+// unsupported timezone if no blocks.json found
+it("returns correct Korean language for locale ko but falls back to UTC", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "ko", "Asia/Seoul")
+	).toMatchInlineSnapshot('"1월 02, 2000  1:00 오전 UTC"');
+});
+
+// supported timezone by default if no blocks.json found
+// supported language en to show am/pm
+// Pacific/Auckland GMT+13
+it("supports Auckland timezone", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Pacific/Auckland")
+	).toMatchInlineSnapshot('"January 02, 2000  2:00 pm NZDT"');
+});
+
+// supported timezone by default if no blocks.json found
+// paris (GMT+1)
+it("supports Paris timezone", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Europe/Paris")
+	).toMatchInlineSnapshot('"January 02, 2000  2:00 am CET"');
+});
+
+it("handles french meridiems", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "fr", "Europe/Paris")
+	).toMatchInlineSnapshot('"janvier 02, 2000  2:00 am CET"');
+});
+
+it("handles spanish meridiems", () => {
+	expect(
+		localizeDateHelper("2000-01-02 13:00", "%B %d, %Y %l:%M %P %Z", "es", "Europe/Paris")
+	).toMatchInlineSnapshot('"enero 02, 2000  2:00 pm CET"');
+});

--- a/src/utils/localize-date/valid-date-format.js
+++ b/src/utils/localize-date/valid-date-format.js
@@ -1,0 +1,21 @@
+// deferred:
+// no numbers (perhaps unnecessary if someone wants "%d %M %Y in the era of the 1st human species")
+
+// trying to guess all of the %{letter} permutations that are allowed
+// the library timezone includes all GNU date extensions plus some more
+// via https://bigeasy.github.io/timezone/#section-54
+
+// should pass:
+// '%dffff' can have anything after matching %{letter}
+function isValidDateFormatString(potentiallyDateString) {
+	// is not null (returns typeof object)
+	// is a string
+	if (typeof potentiallyDateString !== "string") {
+		return false;
+	}
+	// contains at least one % sign
+	// contains at least one %{letter}
+	return /%[a-zA-Z]/.test(potentiallyDateString);
+}
+
+export default isValidDateFormatString;

--- a/src/utils/localize-date/valid-date-format.test.js
+++ b/src/utils/localize-date/valid-date-format.test.js
@@ -1,0 +1,23 @@
+import isValidDateFormatString from "./valid-date-format";
+
+describe("Date format validater", () => {
+	it("allows a date with valid %{letter} format", () => {
+		expect(isValidDateFormatString("%d")).toBe(true);
+	});
+	it("allows a date format with a %{letter}fff letters after", () => {
+		// will return '1fffff'
+		expect(isValidDateFormatString("%dffff")).toBe(true);
+	});
+	it("allows a date format with many %{letter}%{letter} valid options", () => {
+		expect(isValidDateFormatString("%d%d")).toBe(true);
+	});
+	it("disallows a date format that is null", () => {
+		expect(isValidDateFormatString(null)).toBe(false);
+	});
+	it("disallows a date format that is undefined", () => {
+		expect(isValidDateFormatString(undefined)).toBe(false);
+	});
+	it("does not pass a date format with only a %{number}", () => {
+		expect(isValidDateFormatString("%5")).toBe(false);
+	});
+});


### PR DESCRIPTION
## Ticket

- [THEMES-1073](https://arcpublishing.atlassian.net/browse/THEMES-1073)

## Description

This PR adds the localizeDate and localizeDateTime utilities that were in `engine-theme-sdk` to this repo.

## Acceptance Criteria

- updating import references
- remove mocks from tests (if exist)

## Test Steps

1. Checkout branch - `git checkout THEMES-1073`
2. Update dependencies - `npm i`
3. Run tests `npm run test`
4. Ensure all of the tests for the new utilities are passing.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1073]: https://arcpublishing.atlassian.net/browse/THEMES-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ