### PR TITLE
THEMES-1073: Postinstall script for timezone package

### DIFF
--- a/debugging-timezone-postinstall-dates.md
+++ b/debugging-timezone-postinstall-dates.md
@@ -1,0 +1,280 @@
+# How to debug [`@wpmedia/timezone`](https://github.com/WPMedia/timezone) postinstall script
+
+A postinstall script runs after an install (see [more](https://docs.npmjs.com/cli/v7/using*npm/scripts)).
+
+## If no src/blocks.json found
+
+In this postinstall script, if no `blocks.json` file is found, the script will infer some timezones and locales that are included. This is based off of preexisting usage. A timezone is a region that the user is in. A locale is a language that the user is using in that region. For example, a user in the United States might use `en_US` for their locale, and `America/Chicago` for their timezone. You can find the default timezones and locales here in the [scripts/postinstall.js](./scripts/postinstall.js) file:
+
+```js
+// scripts/postinstall.js
+// set themes locale list default if target blocks.json file not found
+themesLocaleList = ["en", "sv", "no", "fr", "de", "es", "ja", "ko"];
+
+// set timezones default if target blocks.json file not found
+targetTimeZones = [
+	"Europe/Paris",
+	"Europe/Oslo",
+	"Europe/Stockholm",
+	"America/New_York",
+	"America/Chicago",
+	"America/Los_Angeles",
+	"America/Mexico_City",
+	"Pacific/Auckland",
+];
+```
+
+The tests currently support this default:
+
+```js
+// src/utils/localizeDate.test.js
+// supported timezone by default if no blocks.json found
+// paris (GMT+1)
+it("supports Paris timezone", () => {
+	expect(
+		localizeDateHelper("2000*01*02 01:00", "%B %d, %Y %l:%M %P %Z", "en", "Europe/Paris")
+	).toMatchInlineSnapshot('"January 02, 2000  2:00 am CET"');
+});
+```
+
+## If wanting to customize blocks.json
+
+To test this locally, add a `blocks.json` to the `src` folder. You'll already notice that this is ignored by git in the `.gitignore` . You can find a valid, test\*passing blocks.json here:
+
+<details>
+  <summary>Click to see blocks.json</summary>
+
+```json
+{
+	"values": {
+		"default": {
+			"siteProperties": {
+				"dateLocalization": {
+					"language": "en",
+					"timeZone": "America/New_York"
+				}
+			}
+		},
+		"sites": {
+			"the*sun": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "fr",
+						"timeZone": "Europe/Paris"
+					}
+				}
+			},
+			"the*prophet": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "no",
+						"timeZone": "Europe/Oslo"
+					}
+				}
+			},
+			"dagen": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "sv",
+						"timeZone": "Europe/Stockholm"
+					}
+				}
+			},
+			"site*with*empty*site*properties": {
+				"siteProperties": {}
+			},
+			"arc*demo*1": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "es",
+						"timeZone": "Europe/Madrid"
+					}
+				}
+			},
+			"arc*demo*2": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "de",
+						"timeZone": "Europe/Busingen"
+					}
+				}
+			},
+			"arc*demo*3": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "ja",
+						"timeZone": "Asia/Tokyo"
+					}
+				}
+			},
+			"arc*demo*4": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "ko",
+						"timeZone": "America/New_York"
+					}
+				}
+			},
+			"portugal*paper": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "pt_PT",
+						"timeZone": "Europe/Lisbon"
+					}
+				}
+			},
+			"arc*demo*korea": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "ko",
+						"timeZone": "America/New_York"
+					}
+				}
+			},
+			"new*zealand*paper": {
+				"siteProperties": {
+					"dateLocalization": {
+						"language": "en",
+						"timeZone": "Pacific/Auckland"
+					}
+				}
+			},
+			"empty-obj": {
+				"siteProperties": {
+					"dateLocalization": {}
+				}
+			}
+		}
+	}
+}
+```
+
+</details>
+
+You may notice `"portugal*paper"` has a differently\*formatted `dateLocalization.language`:
+
+```json
+"portugal*paper": {
+  "siteProperties": {
+    "dateLocalization": {
+      "language": "pt_PT"
+    }
+  }
+}
+```
+
+That's because it's using the full locale with language and region (`region + language = locale`). We're maintaining the mappings of "en", for example, due to preexisting usage:
+
+| `dateLocalization.language` | Output locale |
+| --------------------------- | ------------- |
+| sv                          | sv_SE         |
+| fr                          | fr_FR         |
+| no                          | nb_NO         |
+| es                          | es_ES         |
+| ja                          | ja_JP         |
+| ko                          | ko_KR         |
+| en                          | en_US         |
+
+To see all locales supported:
+
+<details>
+  <summary>See all locales, click expand</summary>
+
+- sv_SE
+- fr_FR
+- nb_NO
+- es_ES
+- ja_JP
+- ko_KR
+- en_US
+- af_ZA
+- am_ET
+- ast_ES
+- bg_BG
+- bn_BD
+- bn_IN
+- ca_ES
+- cs_CZ
+- de_AT
+- de_CH
+- el_GR
+- en_AU
+- en_CA
+- en_GB
+- en_HK
+- en_NZ
+- es_AR
+- es_CL
+- es_CO
+- es_CR
+- es_DO
+- es_EC
+- es_GT
+- es_HN
+- es_MX
+- es_NI
+- es_PA
+- es_PE
+- es_PR
+- es_SV
+- es_UY
+- es_VE
+- eu_ES
+- fi_FI
+- fr_BE
+- fr_CA
+- fr_CH
+- gl_ES
+- he_IL
+- hi_IN
+- hr_HR
+- hu_HU
+- id_ID
+- it_CH
+- it_IT
+- lt_LT
+- lv_LV
+- ms_MY
+- nds_DE
+- nl_BE
+- nl_NL
+- pl_PL
+- pt_BR
+- pt_PT
+- ru_RU
+- si_LK
+- sl_SI
+- sq_AL
+- sr_RS
+- ta_IN
+- uk_UA
+- ur_PK
+- vi_VN
+- zh_CN
+- zh_HK
+- zh_TW
+</details>
+
+To test this live, run
+
+`rm rf node_modules && npm ci`
+
+To see the included locales (language and country) and folders:
+`ls node_modules/@wpmedia/timezone/`
+
+To test including blocks.json, use the included blocks.json above and uncomment the following test:
+
+```ts
+// localizeDate.test.ts
+it("support portuguese in portugal language and portugal lisbon timezone when setup with blocks.json", () => {
+	expect(
+		localizeDateHelper("2000-01-02 01:00", "%B %d, %Y %l:%M %P %Z", "pt_PT", "Europe/Lisbon")
+	).toMatchInlineSnapshot('"Janeiro 02, 2000  1:00  WET"');
+});
+```
+
+# Resources
+
+- To find available more IANA timezones: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+- WPMedia Fork: https://github.com/WPMedia/timezone of original https://bigeasy.github.io/timezone/
+- See timezone library documentation https://bigeasy.github.io/timezone/

--- a/jest.config.js
+++ b/jest.config.js
@@ -33,5 +33,6 @@ module.exports = {
 		"!.*.js",
 		"!__tests__/scss.test.js",
 		"!_templates/**",
+		"!**/scripts/**",
 	],
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:styles": "stylelint '**/*.scss' --formatter verbose",
     "lint:styles:fix": "stylelint '**/*.scss' --fix",
     "generate:component": "hygen component new",
+    "postinstall": "node scripts/postinstall.js",
     "prepare": "husky install",
     "storybook": "start-storybook -p 60003",
     "storybook:build": "build-storybook",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,288 @@
+const fs = require("fs");
+
+// get blocks json allowed strings
+
+let themesLocaleList = [];
+
+let targetTimeZones = [];
+
+const packageName = "@wpmedia/timezone";
+
+// in this case, wherever npm i was called
+// init cwd is the filepath of the initiating command
+const dirPath = `${process.env.INIT_CWD}/node_modules/${packageName}/`;
+
+let targetBlockValues = {};
+try {
+	// eslint-disable-next-line global-require,import/no-dynamic-require
+	targetBlockValues = require(`${process.env.INIT_CWD}/src/blocks.json`).values;
+
+	const defaultLocalizationObject = targetBlockValues.default.siteProperties.dateLocalization;
+
+	// must have a default language and timezone
+	// redefining locale list over the defaults
+	themesLocaleList = [defaultLocalizationObject.language];
+	targetTimeZones = [defaultLocalizationObject.timeZone];
+	/*
+    "sites": {
+      "arc-demo-1": {
+      "siteProperties": {
+        "dateLocalization": {
+          "language": "es",
+          "timeZone": "Europe/Madrid"
+        },
+      }
+    }
+  */
+
+	// if sites
+	// obj with key is truthy if sites property exists
+	Object.values(targetBlockValues.sites).forEach(({ siteProperties: sitePropertyObject }) => {
+		// if site has no date localization obj
+		if (sitePropertyObject.dateLocalization) {
+			if (typeof sitePropertyObject.dateLocalization.language === "string") {
+				themesLocaleList.push(sitePropertyObject.dateLocalization.language);
+			}
+			if (typeof sitePropertyObject.dateLocalization.timeZone === "string") {
+				targetTimeZones.push(sitePropertyObject.dateLocalization.timeZone);
+			}
+		}
+	});
+
+	// dedupe languages and timezones if any added
+	themesLocaleList = [...new Set(themesLocaleList)];
+	targetTimeZones = [...new Set(targetTimeZones)];
+} catch (err) {
+	// set themes locale list default if target blocks.json file not found
+	themesLocaleList = ["de", "en", "es", "fr", "ja", "ko", "no", "pt", "sv"];
+
+	// set timezones default if target blocks.json file not found
+	targetTimeZones = [
+		"America/Chicago",
+		"America/Los_Angeles",
+		"America/New_York",
+		"America/Mexico_City",
+		"Europe/Lisbon",
+		"Europe/Oslo",
+		"Europe/Paris",
+		"Europe/Stockholm",
+		"Pacific/Auckland",
+	];
+
+	// if debugging file paths locally this could be helpful
+	// nested dependency postinstall logging doesn't bubble up sadly in compiler
+	// installed here https://github.com/WPMedia/fusion/blob/927f59d2723551f3f381363ca74ecaae8dd1ef87/compiler/src/compile.js#L63
+	// console.log(`${process.env.INIT_CWD}/src/blocks.json`, 'not found');
+}
+
+function unlinkSyncWithErrorLogging(targetPath) {
+	try {
+		fs.unlinkSync(targetPath);
+	} catch (err) {
+		// if debugging locally, this logging can be helpful
+		// in the fusion compiler, this logging would not bubble up
+		// as far as I understand, nested dependency postinstall scripts don't log
+		// also interestingly, if you run `rm -rf node_modules && npm i && npm i`
+		// you would see this log because the double install
+		// only installs once but the postinstall script runs twice
+		// https://docs.npmjs.com/cli/v7/using-npm/scripts
+		// console.log(targetPath, 'not deleted');
+	}
+}
+
+// input: themes locale
+// output: timezone-compatible locale
+function mapThemesLocales(themesLocaleString) {
+	let locale = "";
+
+	// via localizeDateHelper
+	switch (themesLocaleString) {
+		case "de":
+			locale = "de_DE";
+			break;
+		case "en":
+			locale = "en_US";
+			break;
+		case "es":
+			locale = "es_ES";
+			break;
+		case "fr":
+			locale = "fr_FR";
+			break;
+		case "ja":
+			locale = "ja_JP";
+			break;
+		case "ko":
+			locale = "ko_KR";
+			break;
+		case "no":
+			locale = "nb_NO";
+			break;
+		case "pt":
+			locale = "pt_PT";
+			break;
+		case "sv":
+			locale = "sv_SE";
+			break;
+		default:
+			locale = themesLocaleString;
+	}
+	return locale;
+}
+
+const DELETABLE_FILES = [
+	"CHANGELOG",
+	"README.md",
+
+	"synopsis.js", // used for tutorial purposes
+	"loaded.js", // loads everything, we're only using zones.js and locales.js
+];
+
+// the timezones require these base timezone files
+const TIMEZONE_CODES = [
+	"CET.js",
+	"CST6CDT.js",
+	"EET.js",
+	"EST.js",
+	"EST5EDT.js",
+	"HST.js",
+	"MET.js",
+	"MST.js",
+	"MST7MDT.js",
+	"PST8PDT.js",
+	"WET.js",
+];
+
+// all keeping js
+const packageKeepLocaleList = themesLocaleList.map(
+	(themeLocale) => `${mapThemesLocales(themeLocale)}.js`
+);
+
+function outputExportsString(targetFileNamesArray, fileExtension = "") {
+	let requireStatements = "";
+
+	targetFileNamesArray.forEach((targetFileNameWithExtension) => {
+		requireStatements += `require("./${targetFileNameWithExtension}${fileExtension}"),`;
+	});
+
+	return `module.exports = [${requireStatements}]`;
+}
+
+// many files have no chance of being picked in blocks.json
+function deleteUnnecessaryFiles() {
+	DELETABLE_FILES.forEach((unnecessaryFileString) =>
+		unlinkSyncWithErrorLogging(`${dirPath}${unnecessaryFileString}`)
+	);
+}
+
+function deleteUnusedFiles() {
+	// take in locale list
+
+	const TIMEZONE_ALLOW_LIST = [
+		"index.js", // entry
+		"package.json",
+		"rfc822.js",
+		"locales.js", // requires all locales
+		"zones.js", // loads all timezones
+	];
+
+	fs.readdirSync(dirPath).forEach((fileName) => {
+		if (
+			!packageKeepLocaleList.includes(fileName) &&
+			fs.lstatSync(`${dirPath}${fileName}`).isFile() &&
+			!TIMEZONE_ALLOW_LIST.includes(fileName) &&
+			!TIMEZONE_CODES.includes(fileName)
+		) {
+			unlinkSyncWithErrorLogging(`${dirPath}${fileName}`);
+		}
+	});
+}
+
+// incoming ['Pacific/Auckland',]
+
+function loopAndSetTimezoneContinents(incomeTargetTimezones) {
+	const incomingTimezonesObject = incomeTargetTimezones.reduce((outputObject, currentItem) => {
+		const [topLevelTimezone, nestedTimezone] = currentItem.split("/");
+		const newOutputObject = outputObject;
+		newOutputObject[topLevelTimezone] = [...(outputObject[topLevelTimezone] || []), nestedTimezone];
+
+		return newOutputObject;
+	}, {});
+
+	const incomingTimezonesArray = Object.keys(incomingTimezonesObject);
+
+	const ALL_TOPLEVEL_TIMEZONES = [
+		"Africa",
+		"America",
+		"Antarctica",
+		"Arctic",
+		"Asia",
+		"Atlantic",
+		"Australia",
+		"Brazil",
+		"Canada",
+		"Chile",
+		"Etc",
+		"Europe",
+		"Indian",
+		"Mexico",
+		"Pacific",
+		"US",
+	];
+
+	ALL_TOPLEVEL_TIMEZONES.forEach((topLevelTimezoneFolder) => {
+		if (!incomingTimezonesArray.includes(topLevelTimezoneFolder)) {
+			fs.rmdirSync(`${dirPath}${topLevelTimezoneFolder}`, { recursive: true }, (err) => {
+				if (err) {
+					throw err;
+				}
+			});
+		} else {
+			const targetNestedTimezones = incomingTimezonesObject[topLevelTimezoneFolder];
+			fs.readdirSync(`${dirPath}${topLevelTimezoneFolder}`).forEach((nestedFile) => {
+				const fileNameWithoutExtension = nestedFile.split(".")[0];
+				// want to keep index files
+				const targetFilePath = `${dirPath}${topLevelTimezoneFolder}/${nestedFile}`;
+
+				if (
+					!targetNestedTimezones.includes(fileNameWithoutExtension) &&
+					fileNameWithoutExtension !== "index"
+				) {
+					if (fs.lstatSync(targetFilePath).isFile()) {
+						unlinkSyncWithErrorLogging(targetFilePath);
+					} else {
+						fs.rmdirSync(targetFilePath, { recursive: true }, (err) => {
+							if (err) {
+								throw err;
+							}
+						});
+					}
+				}
+
+				if (fileNameWithoutExtension === "index") {
+					fs.writeFileSync(targetFilePath, outputExportsString(targetNestedTimezones, ".js"));
+				}
+			});
+		}
+	});
+	// output what should be required
+	const allRequireStatementsArray = [...TIMEZONE_CODES, ...incomingTimezonesArray];
+	return outputExportsString(allRequireStatementsArray);
+}
+
+function updateEntryFileRequiredFiles() {
+	// only add back the the locales used
+
+	const startingLocaleString = outputExportsString(packageKeepLocaleList);
+	const startingOutputString = loopAndSetTimezoneContinents(targetTimeZones);
+	fs.writeFileSync(`${dirPath}zones.js`, startingOutputString);
+	fs.writeFileSync(`${dirPath}locales.js`, startingLocaleString);
+}
+
+// delete files that are never used
+deleteUnnecessaryFiles();
+
+// delete files that may be needed
+deleteUnusedFiles();
+
+updateEntryFileRequiredFiles();


### PR DESCRIPTION
## Ticket

- [THEMES-1073](https://arcpublishing.atlassian.net/browse/THEMES-1073)

## Description

Follow up to the last PR (https://github.com/WPMedia/arc-themes-components/pull/176), this adds a postinstall script from `engine-theme-sdk` to manage the size of the timezone package.

## Test Steps

1. Checkout branch - `git checkout THEMES-1073-postinstall`
2. Remove the node modules folder `rm -rf node_modules`
3. Update dependencies - `npm i`
4. Check that the `node_modules/@wpmedia/timezone` folder is of a more reasonable size (172KB on my machine, down from 3.4MB).
5. Run tests `npm run test`
6. They all should pass still.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1073]: https://arcpublishing.atlassian.net/browse/THEMES-1073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ