### PR TITLE
THEMES-1086: Move resizer URL

### DIFF
--- a/.storybook/alias/environment.js
+++ b/.storybook/alias/environment.js
@@ -1,4 +1,3 @@
 export default () => ({
 	RESIZER_TOKEN_VERSION: "",
-	RESIZER_URL: "https://arc/resizer/v2/",
 });

--- a/.storybook/alias/properties.js
+++ b/.storybook/alias/properties.js
@@ -1,3 +1,4 @@
 export default () => ({
 	locale: "en",
+	resizerURL: "https://arc/resizer/v2/",
 });

--- a/jest/mocks/environment.js
+++ b/jest/mocks/environment.js
@@ -1,5 +1,4 @@
 const RESIZER_TOKEN_VERSION = 2;
 
-const RESIZER_URL = "http://url.com/";
-
-export { RESIZER_TOKEN_VERSION, RESIZER_URL };
+// eslint-disable-next-line import/prefer-default-export
+export { RESIZER_TOKEN_VERSION };

--- a/jest/mocks/properties.js
+++ b/jest/mocks/properties.js
@@ -1,3 +1,4 @@
 export default jest.fn(() => ({
 	locale: "en",
+	resizerURL: "http://url.com/",
 }));

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -1,5 +1,7 @@
 import PropTypes from "prop-types";
-import { RESIZER_TOKEN_VERSION, RESIZER_URL } from "fusion:environment";
+import { useFusionContext } from "fusion:context";
+import { RESIZER_TOKEN_VERSION } from "fusion:environment";
+import getProperties from "fusion:properties";
 import formatSrc from "../../utils/format-image-resizer-src";
 import imageANSToImageSrc from "../../utils/image-ans-to-image-src";
 import calculateWidthAndHeight from "./calculate-width-height";
@@ -23,11 +25,13 @@ const Image = ({
 }) => {
 	const auth = ansImage ? ansImage.auth[RESIZER_TOKEN_VERSION] : resizedOptions?.auth;
 	const formattedSrc = ansImage ? imageANSToImageSrc(ansImage) : src;
-
+	const { arcSite } = useFusionContext();
+	const { resizerURL: defaultResizerURL } = getProperties(arcSite);
+	const resizerURLToUse = resizerURL || defaultResizerURL;
 	const componentClassNames = className
 		? `${COMPONENT_CLASS_NAME} ${className}`
 		: COMPONENT_CLASS_NAME;
-
+	console.log("RESIZER_TOKEN_VERSION", RESIZER_TOKEN_VERSION);
 	if (!auth) {
 		// eslint-disable-next-line no-console
 		console.error("No auth token provided for resizer");
@@ -39,14 +43,14 @@ const Image = ({
 
 	const imageWidthAndHeight = calculateWidthAndHeight({ aspectRatio, width, height, ansImage });
 	const imageAspectRatio = imageWidthAndHeight.width / imageWidthAndHeight.height;
-
+	console.log("formattedSrc", formattedSrc);
 	const defaultSrc = formatSrc(
-		resizerURL.concat(formattedSrc),
+		resizerURLToUse.concat(formattedSrc),
 		{ ...resizedOptions, auth },
 		imageWidthAndHeight.width,
 		imageWidthAndHeight.height
 	);
-
+	console.log("defaultSrc", defaultSrc);
 	const responsiveSrcSet =
 		responsiveImages
 			.filter(
@@ -54,7 +58,7 @@ const Image = ({
 			)
 			.map((responsiveImageWidth) =>
 				formatSrc(
-					resizerURL.concat(formattedSrc),
+					resizerURLToUse.concat(formattedSrc),
 					{ ...resizedOptions, auth },
 					responsiveImageWidth,
 					imageAspectRatio !== 0 ? responsiveImageWidth / imageAspectRatio : undefined
@@ -72,7 +76,7 @@ const Image = ({
 					)
 					.join(", ")
 			: null;
-
+	console.log("returning image with src: ", defaultSrc);
 	return (
 		<img
 			{...rest}
@@ -92,7 +96,6 @@ Image.defaultProps = {
 	alt: "",
 	loading: "lazy",
 	resizedOptions: {},
-	resizerURL: RESIZER_URL || "",
 	responsiveImages: [],
 	sizes: [],
 };

--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -31,7 +31,6 @@ const Image = ({
 	const componentClassNames = className
 		? `${COMPONENT_CLASS_NAME} ${className}`
 		: COMPONENT_CLASS_NAME;
-	console.log("RESIZER_TOKEN_VERSION", RESIZER_TOKEN_VERSION);
 	if (!auth) {
 		// eslint-disable-next-line no-console
 		console.error("No auth token provided for resizer");
@@ -43,14 +42,14 @@ const Image = ({
 
 	const imageWidthAndHeight = calculateWidthAndHeight({ aspectRatio, width, height, ansImage });
 	const imageAspectRatio = imageWidthAndHeight.width / imageWidthAndHeight.height;
-	console.log("formattedSrc", formattedSrc);
+
 	const defaultSrc = formatSrc(
 		resizerURLToUse.concat(formattedSrc),
 		{ ...resizedOptions, auth },
 		imageWidthAndHeight.width,
 		imageWidthAndHeight.height
 	);
-	console.log("defaultSrc", defaultSrc);
+
 	const responsiveSrcSet =
 		responsiveImages
 			.filter(
@@ -76,7 +75,7 @@ const Image = ({
 					)
 					.join(", ")
 			: null;
-	console.log("returning image with src: ", defaultSrc);
+
 	return (
 		<img
 			{...rest}

--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -281,7 +281,7 @@ describe("Image", () => {
 		render(
 			<Image
 				ansImage={{
-					_id: 123,
+					_id: "123",
 					url: "test-image.jpg",
 					auth: {
 						2: "secret",


### PR DESCRIPTION
## Ticket

- [THEMES-1086](https://arcpublishing.atlassian.net/browse/THEMES-1086)

## Description

This is the themes components update for moving the resizerURL back to site properties to stay consistent with 1.x.

## Acceptance Criteria

The resizer url is a site property in Themes Settings, not an env variable

## Test Steps

1. Checkout branch - `git checkout THEMES-1086`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. The Image component should be loading as expected.
5. See Blocks PR (https://github.com/WPMedia/arc-themes-blocks/pull/1654) for further instructions.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- x ] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1086]: https://arcpublishing.atlassian.net/browse/THEMES-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ