### PR TITLE
Themes 1289 V2 Video Center | Arc block - video needs to resize to handle the correct size when we have vertical video

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ import formatCredits from "./src/utils/format-credits";
 import formatPowaVideoEmbed from "./src/utils/format-powa-video-embed";
 import formatSocialURL from "./src/utils/format-social-url";
 import formatURL from "./src/utils/format-url";
+import getAspectRatio from "./src/utils/get-aspect-ratio";
 
 // the following are ordered by dependency
 import getImageFromANS from "./src/utils/get-image-from-ans";
@@ -63,6 +64,7 @@ export {
 	formatPowaVideoEmbed,
 	formatSocialURL,
 	formatURL,
+	getAspectRatio,
 	getImageFromANS,
 	getPromoType,
 	getVideoFromANS,

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -26,7 +26,7 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	// If the aspect ratio is passed in (promo blocks do this), then use that instead
 	if (aspectRatio) {
-		console.log("If statement triggered");
+		// console.log("If statement triggered");
 		// const [w, h] = aspectRatio.split(":");
 
 		const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
@@ -64,16 +64,12 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 		const embedAspectRatio = parseFloat(searchResult[1]);
 		const videoAspectRatio = truncate(1 / embedAspectRatio);
 
-		console.log(
-			`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`
-		);
+		// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
 
 		const embedMarkupWithAspectRatio = embedMarkup;
 
 		// console.log("-----------------------------------------------------------");
-		console.log(
-			`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`
-		);
+		// console.log(`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`);
 		// console.log(`Calculated aspect ratio: ${truncate(w / h)}`);
 		// console.log(`Calculated videoAspectRatio: ${videoAspectRatio}`);
 		// console.log(embedMarkup);

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -21,35 +21,90 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	const truncate = (num) => Math.trunc(num * 10000) / 10000;
 
-	const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
-	const videoAspectRatio = truncate(h / w);
+	// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
+	let retVal;
 
-	const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
-		"aspect-ratio": videoAspectRatio,
-	});
+	// If the aspect ratio is passed in (promo blocks do this), then use that instead
+	if (aspectRatio) {
+		console.log("If statement triggered");
+		// const [w, h] = aspectRatio.split(":");
 
-	return (
-		<div className={`${COMPONENT_CLASS_NAME}__frame`}>
-			<div
-				{...rest}
-				className={containerClassNames}
-				style={{
-					"--aspect-ratio": truncate(w / h),
-					"--height": viewportPercentage,
-				}}
-			>
-				{shouldRenderVideoContent ? (
-					<EmbedContainer markup={embedMarkupWithAspectRatio}>
-						<div
-							dangerouslySetInnerHTML={{
-								__html: embedMarkupWithAspectRatio,
-							}}
-						/>
-					</EmbedContainer>
-				) : null}
+		const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
+		const videoAspectRatio = truncate(h / w);
+
+		const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
+			"aspect-ratio": videoAspectRatio,
+		});
+
+		retVal = (
+			<div className={`${COMPONENT_CLASS_NAME}__frame`}>
+				<div
+					{...rest}
+					className={containerClassNames}
+					style={{
+						"--aspect-ratio": truncate(w / h),
+						"--height": viewportPercentage,
+					}}
+				>
+					{shouldRenderVideoContent ? (
+						<EmbedContainer markup={embedMarkupWithAspectRatio}>
+							<div
+								dangerouslySetInnerHTML={{
+									__html: embedMarkupWithAspectRatio,
+								}}
+							/>
+						</EmbedContainer>
+					) : null}
+				</div>
 			</div>
-		</div>
-	);
+		);
+	} else {
+		// Extract the aspect ratio from embedMarkup
+		const searchResult = /data-aspect-ratio="([.0-9]+)"/.exec(embedMarkup);
+		const embedAspectRatio = parseFloat(searchResult[1]);
+		const videoAspectRatio = truncate(1 / embedAspectRatio);
+
+		console.log(
+			`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`
+		);
+
+		const embedMarkupWithAspectRatio = embedMarkup;
+
+		// console.log("-----------------------------------------------------------");
+		console.log(
+			`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`
+		);
+		// console.log(`Calculated aspect ratio: ${truncate(w / h)}`);
+		// console.log(`Calculated videoAspectRatio: ${videoAspectRatio}`);
+		// console.log(embedMarkup);
+		// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
+		// console.log("-----------------------------------------------------------");
+
+		retVal = (
+			<div className={`${COMPONENT_CLASS_NAME}__frame`}>
+				<div
+					{...rest}
+					className={containerClassNames}
+					style={{
+						"--aspect-ratio": videoAspectRatio,
+						"--height": viewportPercentage,
+					}}
+				>
+					{shouldRenderVideoContent ? (
+						<EmbedContainer markup={embedMarkupWithAspectRatio}>
+							<div
+								dangerouslySetInnerHTML={{
+									__html: embedMarkupWithAspectRatio,
+								}}
+							/>
+						</EmbedContainer>
+					) : null}
+				</div>
+			</div>
+		);
+	}
+
+	return retVal;
 };
 
 Video.propTypes = {

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -56,7 +56,7 @@ Video.propTypes = {
 	/** Class name(s) that get appended to default class name of the component */
 	className: PropTypes.string,
 	/** The aspect ratio of the video */
-	aspectRatio: PropTypes.oneOf(["16:9", "3:2", "4:3"]),
+	aspectRatio: PropTypes.string,
 	/* The vertical percentage of the viewport takes up */
 	viewportPercentage: PropTypes.number,
 };

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -21,90 +21,35 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	const truncate = (num) => Math.trunc(num * 10000) / 10000;
 
-	// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
-	let retVal;
+	const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
+	const videoAspectRatio = truncate(h / w);
 
-	// If the aspect ratio is passed in (promo blocks do this), then use that instead
-	if (aspectRatio) {
-		console.log("If statement triggered");
-		// const [w, h] = aspectRatio.split(":");
+	const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
+		"aspect-ratio": videoAspectRatio,
+	});
 
-		const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
-		const videoAspectRatio = truncate(h / w);
-
-		const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
-			"aspect-ratio": videoAspectRatio,
-		});
-
-		retVal = (
-			<div className={`${COMPONENT_CLASS_NAME}__frame`}>
-				<div
-					{...rest}
-					className={containerClassNames}
-					style={{
-						"--aspect-ratio": truncate(w / h),
-						"--height": viewportPercentage,
-					}}
-				>
-					{shouldRenderVideoContent ? (
-						<EmbedContainer markup={embedMarkupWithAspectRatio}>
-							<div
-								dangerouslySetInnerHTML={{
-									__html: embedMarkupWithAspectRatio,
-								}}
-							/>
-						</EmbedContainer>
-					) : null}
-				</div>
+	return (
+		<div className={`${COMPONENT_CLASS_NAME}__frame`}>
+			<div
+				{...rest}
+				className={containerClassNames}
+				style={{
+					"--aspect-ratio": truncate(w / h),
+					"--height": viewportPercentage,
+				}}
+			>
+				{shouldRenderVideoContent ? (
+					<EmbedContainer markup={embedMarkupWithAspectRatio}>
+						<div
+							dangerouslySetInnerHTML={{
+								__html: embedMarkupWithAspectRatio,
+							}}
+						/>
+					</EmbedContainer>
+				) : null}
 			</div>
-		);
-	} else {
-		// Extract the aspect ratio from embedMarkup
-		const searchResult = /data-aspect-ratio="([.0-9]+)"/.exec(embedMarkup);
-		const embedAspectRatio = parseFloat(searchResult[1]);
-		const videoAspectRatio = truncate(1 / embedAspectRatio);
-
-		console.log(
-			`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`
-		);
-
-		const embedMarkupWithAspectRatio = embedMarkup;
-
-		// console.log("-----------------------------------------------------------");
-		console.log(
-			`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`
-		);
-		// console.log(`Calculated aspect ratio: ${truncate(w / h)}`);
-		// console.log(`Calculated videoAspectRatio: ${videoAspectRatio}`);
-		// console.log(embedMarkup);
-		// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
-		// console.log("-----------------------------------------------------------");
-
-		retVal = (
-			<div className={`${COMPONENT_CLASS_NAME}__frame`}>
-				<div
-					{...rest}
-					className={containerClassNames}
-					style={{
-						"--aspect-ratio": videoAspectRatio,
-						"--height": viewportPercentage,
-					}}
-				>
-					{shouldRenderVideoContent ? (
-						<EmbedContainer markup={embedMarkupWithAspectRatio}>
-							<div
-								dangerouslySetInnerHTML={{
-									__html: embedMarkupWithAspectRatio,
-								}}
-							/>
-						</EmbedContainer>
-					) : null}
-				</div>
-			</div>
-		);
-	}
-
-	return retVal;
+		</div>
+	);
 };
 
 Video.propTypes = {

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -26,7 +26,7 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	// If the aspect ratio is passed in (promo blocks do this), then use that instead
 	if (aspectRatio) {
-		// console.log("If statement triggered");
+		console.log("If statement triggered");
 		// const [w, h] = aspectRatio.split(":");
 
 		const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
@@ -64,12 +64,16 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 		const embedAspectRatio = parseFloat(searchResult[1]);
 		const videoAspectRatio = truncate(1 / embedAspectRatio);
 
-		// console.log(`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`);
+		console.log(
+			`--- Aspect ratio: ${embedAspectRatio} | VideoAspectRatio: ${videoAspectRatio} ---`
+		);
 
 		const embedMarkupWithAspectRatio = embedMarkup;
 
 		// console.log("-----------------------------------------------------------");
-		// console.log(`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`);
+		console.log(
+			`Passed-in aspectRatio: ${aspectRatio} and viewportPercentage: ${viewportPercentage}`
+		);
 		// console.log(`Calculated aspect ratio: ${truncate(w / h)}`);
 		// console.log(`Calculated videoAspectRatio: ${videoAspectRatio}`);
 		// console.log(embedMarkup);

--- a/src/utils/get-aspect-ratio/index.js
+++ b/src/utils/get-aspect-ratio/index.js
@@ -1,0 +1,39 @@
+/**
+ * Helper that calculates the Greatest Common Denominator (GCD) of two integers.
+ *
+ * @param valA First integer
+ * @param valB Second integer
+ *
+ * @returns An integer representing the GCD of valA and valB
+ */
+const gcd = (valA, valB) => {
+	let a = Math.abs(valA);
+	let b = Math.abs(valB);
+	while (b) {
+		const temp = b;
+		b = a % b;
+		a = temp;
+	}
+
+	return a;
+};
+
+/**
+ * Helper function that calculates the aspect ratio of an image given its width and height.
+ * The resulting aspect ratio is in the form of a string, with the two values seperated by a colon (i.e., "16:9").
+ * The ratio will also be in its simplest form possible (this is what the GCD function helps with).
+ *
+ * @param width Content width in pixels
+ * @param height Content height in pixels
+ *
+ * @returns A string of the form /\d+:\d+/ representing the aspect ratio in simplest form
+ */
+const getAspectRatio = (width, height) => {
+	const divisor = gcd(width, height);
+	const aspectWidth = width / divisor;
+	const aspectHeight = height / divisor;
+
+	return `${aspectWidth}:${aspectHeight}`;
+};
+
+export default getAspectRatio;

--- a/src/utils/get-aspect-ratio/index.js
+++ b/src/utils/get-aspect-ratio/index.js
@@ -4,7 +4,7 @@
  * @param valA First integer
  * @param valB Second integer
  *
- * @returns An integer representing the GCD of valA and valB
+ * @returns An integer representing the GCD of `valA` and `valB`
  */
 const gcd = (valA, valB) => {
 	let a = Math.abs(valA);
@@ -26,7 +26,7 @@ const gcd = (valA, valB) => {
  * @param width Content width in pixels
  * @param height Content height in pixels
  *
- * @returns A string of the form /\d+:\d+/ representing the aspect ratio in simplest form
+ * @returns A string of the form `/\d+:\d+/` representing the aspect ratio in simplest form
  */
 const getAspectRatio = (width, height) => {
 	const divisor = gcd(width, height);

--- a/src/utils/get-aspect-ratio/index.js
+++ b/src/utils/get-aspect-ratio/index.js
@@ -31,7 +31,7 @@ const gcd = (valA, valB) => {
 const getAspectRatio = (width, height) => {
 	// If height is zero, return null
 	if (height === 0) {
-		return null;
+		return undefined;
 	}
 
 	const divisor = gcd(width, height);

--- a/src/utils/get-aspect-ratio/index.js
+++ b/src/utils/get-aspect-ratio/index.js
@@ -29,6 +29,11 @@ const gcd = (valA, valB) => {
  * @returns A string of the form `/\d+:\d+/` representing the aspect ratio in simplest form
  */
 const getAspectRatio = (width, height) => {
+	// If height is zero, return null
+	if (height === 0) {
+		return null;
+	}
+
 	const divisor = gcd(width, height);
 	const aspectWidth = width / divisor;
 	const aspectHeight = height / divisor;

--- a/src/utils/get-aspect-ratio/index.test.js
+++ b/src/utils/get-aspect-ratio/index.test.js
@@ -43,10 +43,10 @@ describe("should correctly calculate the aspect ratio given a width and height",
 		expect(aspectRatio).toEqual("33:100");
 	});
 
-	it("returns null if zero is passed in for the height", () => {
+	it("returns undefined if zero is passed in for the height", () => {
 		const width = 21;
 		const height = 0;
 		const aspectRatio = getAspectRatio(width, height);
-		expect(aspectRatio).toEqual(null);
+		expect(aspectRatio).toEqual(undefined);
 	});
 });

--- a/src/utils/get-aspect-ratio/index.test.js
+++ b/src/utils/get-aspect-ratio/index.test.js
@@ -42,4 +42,11 @@ describe("should correctly calculate the aspect ratio given a width and height",
 		const aspectRatio = getAspectRatio(width, height);
 		expect(aspectRatio).toEqual("33:100");
 	});
+
+	it("returns null if zero is passed in for the height", () => {
+		const width = 21;
+		const height = 0;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual(null);
+	});
 });

--- a/src/utils/get-aspect-ratio/index.test.js
+++ b/src/utils/get-aspect-ratio/index.test.js
@@ -22,21 +22,21 @@ describe("should correctly calculate the aspect ratio given a width and height",
 		expect(aspectRatio).toEqual("4:3");
 	});
 
-	it("does not incorrectly simplify a 1 x 1 content item", () => {
+	it("does not incorrectly simplify a 1 x 1 content item's aspect ratio", () => {
 		const width = 1;
 		const height = 1;
 		const aspectRatio = getAspectRatio(width, height);
 		expect(aspectRatio).toEqual("1:1");
 	});
 
-	it("does not incorrectly simplify a 13 x 5 content item", () => {
+	it("does not incorrectly simplify a 13 x 5 content item's aspect ratio", () => {
 		const width = 13;
 		const height = 5;
 		const aspectRatio = getAspectRatio(width, height);
 		expect(aspectRatio).toEqual("13:5");
 	});
 
-	it("does not incorrectly simplify a 33 x 100 content item", () => {
+	it("does not incorrectly simplify a 33 x 100 content item's aspect ratio", () => {
 		const width = 33;
 		const height = 100;
 		const aspectRatio = getAspectRatio(width, height);

--- a/src/utils/get-aspect-ratio/index.test.js
+++ b/src/utils/get-aspect-ratio/index.test.js
@@ -1,0 +1,45 @@
+import getAspectRatio from "./index";
+
+describe("should correctly calculate the aspect ratio given a width and height", () => {
+	it("should correctly evaluate and simplify the aspect ratio to 1:2", () => {
+		const width = 250;
+		const height = 500;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("1:2");
+	});
+
+	it("should correctly evaluate and simplify the aspect ratio to 1:1", () => {
+		const width = 999;
+		const height = 999;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("1:1");
+	});
+
+	it("should correctly evaluate and simplify the aspect ratio to 4:3", () => {
+		const width = 960;
+		const height = 720;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("4:3");
+	});
+
+	it("does not incorrectly simplify a 1 x 1 content item", () => {
+		const width = 1;
+		const height = 1;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("1:1");
+	});
+
+	it("does not incorrectly simplify a 13 x 5 content item", () => {
+		const width = 13;
+		const height = 5;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("13:5");
+	});
+
+	it("does not incorrectly simplify a 33 x 100 content item", () => {
+		const width = 33;
+		const height = 100;
+		const aspectRatio = getAspectRatio(width, height);
+		expect(aspectRatio).toEqual("33:100");
+	});
+});


### PR DESCRIPTION
This goes with **[this blocks PR](https://github.com/WPMedia/arc-themes-blocks/pull/1715)** and [THEMES-1289](https://arcpublishing.atlassian.net/browse/THEMES-1289).

To reduce code duplication, I moved the GCD (Greatest Common Denominator) function and aspect-ratio-calculation function into a `utils` directory in `arc-themes-components`. The blocks in `arc-themes-blocks` that calculate aspect ratio will import and use this.  
  
To prevent division by zero, I updated `getAspectRatio` to return `null` if `height === 0`.  
  
I also added a unit test file that tests basic aspect ratio scenarios.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1289]: https://arcpublishing.atlassian.net/browse/THEMES-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ