### PR TITLE
THEMES-1280 Gallery + Lead Art (mobile) | Update autoplay, progress indicator, carousel, and close controls in focus (expand) view

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -317,6 +317,10 @@
 				carousel-button-enter-full-screen: (
 					padding-left: 0,
 				),
+				carousel-button-exit-full-screen: (
+					padding-left: 0,
+					padding-right: 0,
+				),
 				carousel-button-full-screen: (
 					color: var(--global-white),
 				),
@@ -330,17 +334,23 @@
 					color: var(--global-white),
 				),
 				carousel-controls: (
-					display: flex,
-					padding: 0 0 var(--global-spacing-2) 0,
+					margin-bottom: var(--global-spacing-2),
 				),
 				carousel-fullscreen: (
 					color: var(--global-white),
+					padding: var(--global-spacing-2) 0,
+				),
+				carousel-fullscreen-button-toggle-auto-play: (
+					display: none,
 				),
 				carousel-fullscreen-controls: (
-					padding-top: var(--global-spacing-5),
-					padding-right: var(--global-spacing-5),
-					padding-bottom: 0,
-					padding-left: var(--global-spacing-5),
+					align-items: flex-end,
+					flex-direction: column,
+					padding-top: var(--global-spacing-2),
+					padding-right: var(--global-spacing-2),
+					padding-bottom: var(--global-spacing-2),
+					padding-left: var(--global-spacing-2),
+					place-self: initial,
 				),
 				carousel-icon: (
 					fill: currentColor,
@@ -1370,6 +1380,24 @@
 				),
 				carousel-actions: (
 					display: flex,
+				),
+				carousel-additional-controls: (
+					gap: var(--global-spacing-2),
+					padding: 0 0 0 var(--global-spacing-2),
+				),
+				carousel-fullscreen: (
+					padding: var(--global-spacing-5) 0,
+				),
+				carousel-fullscreen-button-toggle-auto-play: (
+					display: flex,
+				),
+				carousel-fullscreen-controls: (
+					flex-direction: initial,
+					padding-top: var(--global-spacing-5),
+					padding-right: var(--global-spacing-5),
+					padding-bottom: var(--global-spacing-5),
+					padding-left: var(--global-spacing-5),
+					place-self: flex-start,
 				),
 				carousel-track: (
 					gap: var(--global-spacing-6),

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -42,7 +42,6 @@
 	}
 
 	&__actions {
-		display: flex;
 		justify-content: space-between;
 		place-self: center;
 		pointer-events: none;
@@ -174,6 +173,12 @@
 
 			&__image-counter-label {
 				@include scss.component-properties("carousel-fullscreen-image-counter");
+			}
+
+			&__button {
+				&--toggle-auto-play {
+					@include scss.component-properties("carousel-fullscreen-button-toggle-auto-play");
+				}
 			}
 		}
 	}

--- a/src/components/carousel/themes/news.json
+++ b/src/components/carousel/themes/news.json
@@ -78,6 +78,14 @@
 			}
 		}
 	},
+	"carousel-button-exit-full-screen": {
+		"styles": {
+			"default": {
+				"padding-left": "0",
+				"padding-right": "0"
+			}
+		}
+	},
 	"carousel-track": {
 		"styles": {
 			"default": {
@@ -93,10 +101,8 @@
 	"carousel-controls": {
 		"styles": {
 			"default": {
-				"display": "flex",
-				"padding": "0 0 var(--global-spacing-2) 0"
-			},
-			"desktop": {}
+				"margin-bottom": "var(--global-spacing-2)"
+			}
 		}
 	},
 	"carousel-additional-controls": {
@@ -105,7 +111,6 @@
 				"display": "flex"
 			},
 			"desktop": {
-				"display": "flex",
 				"gap": "var(--global-spacing-2)",
 				"padding": "0 0 0 var(--global-spacing-2)"
 			}
@@ -114,20 +119,43 @@
 	"carousel-fullscreen": {
 		"styles": {
 			"default": {
-				"color": "var(--global-white)"
+				"color": "var(--global-white)",
+				"padding": "var(--global-spacing-2) 0"
 			},
-			"desktop": {}
+			"desktop": {
+				"padding": "var(--global-spacing-5) 0"
+			}
 		}
 	},
 	"carousel-fullscreen-controls": {
 		"styles": {
 			"default": {
+				"align-items": "flex-end",
+				"flex-direction": "column",
+				"padding-top": "var(--global-spacing-2)",
+				"padding-right": "var(--global-spacing-2)",
+				"padding-bottom": "var(--global-spacing-2)",
+				"padding-left": "var(--global-spacing-2)",
+				"place-self": "initial"
+			},
+			"desktop": {
+				"flex-direction": "initial",
 				"padding-top": "var(--global-spacing-5)",
 				"padding-right": "var(--global-spacing-5)",
-				"padding-bottom": "0",
-				"padding-left": "var(--global-spacing-5)"
+				"padding-bottom": "var(--global-spacing-5)",
+				"padding-left": "var(--global-spacing-5)",
+				"place-self": "flex-start"
+			}
+		}
+	},
+	"carousel-fullscreen-button-toggle-auto-play": {
+		"styles": {
+			"default": {
+				"display": "none"
 			},
-			"desktop": {}
+			"desktop": {
+				"display": "flex"
+			}
 		}
 	},
 	"carousel-icon": {


### PR DESCRIPTION
## Ticket

- [THEMES-1280](https://arcpublishing.atlassian.net/browse/THEMES-1280)

## Description

- Sets styles for expanding/full-screen view for carousel component

## Acceptance Criteria

GIVEN I am a Media Site User, WHEN I expand a gallery, THEN:

- Styling is consistent with v2 designs on expanded gallery
- progress indicator (x of x)
- captions
- carousel controls (><) are removed to avoid duplication
- close 'x' control

## Test Steps

1. Checkout branch - `git checkout THEMES-1280`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the button storybook documentation

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1280]: https://arcpublishing.atlassian.net/browse/THEMES-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ