### PR TITLE
THEMES 1350 V2 Video Center | Arc block - Remove the black bars from the vertical video in mobile view.

### DIFF
--- a/.storybook/themes/commerce.scss
+++ b/.storybook/themes/commerce.scss
@@ -449,7 +449,7 @@
 					margin: auto,
 				),
 				video-frame: (
-					background-color: var(--global-black),
+					background-color: transparent,
 				),
 			),
 			blocks: (
@@ -768,6 +768,9 @@
 				),
 				carousel-track: (
 					gap: var(--global-spacing-6),
+				),
+				video-frame: (
+					background-color: var(--global-black),
 				),
 			),
 			blocks: (

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -475,7 +475,7 @@
 					margin: auto,
 				),
 				video-frame: (
-					background-color: var(--global-black),
+					background-color: transparent,
 				),
 			),
 			blocks: (
@@ -1373,6 +1373,9 @@
 				),
 				carousel-track: (
 					gap: var(--global-spacing-6),
+				),
+				video-frame: (
+					background-color: var(--global-black),
 				),
 			),
 			blocks: (

--- a/src/components/video/themes/commerce.json
+++ b/src/components/video/themes/commerce.json
@@ -9,6 +9,9 @@
 	"video-frame": {
 		"styles": {
 			"default": {
+				"background-color": "transparent"
+			},
+			"desktop": {
 				"background-color": "var(--global-black)"
 			}
 		}

--- a/src/components/video/themes/news.json
+++ b/src/components/video/themes/news.json
@@ -9,6 +9,9 @@
 	"video-frame": {
 		"styles": {
 			"default": {
+				"background-color": "transparent"
+			},
+			"desktop": {
 				"background-color": "var(--global-black)"
 			}
 		}


### PR DESCRIPTION
## Ticket

[THEMES-1350](https://arcpublishing.atlassian.net/browse/THEMES-1350)

## Description

While testing [1289](https://github.com/WPMedia/arc-themes-blocks/pull/1715), @alshwaikit noted that vertical videos can be ugly on mobile screens. As a minor fix, I added new styling to the `Video` component.

* I added a `desktop` selector in `src/components/video/themes/news.json` and `commerce.json`. I put the old video-frame-background-color CSS in there. Then, I changed the fill for `default` to `transparent` for the video frame. This makes it so mobile videos don't have black bars on the sides, which looks better. **Note that nothing about the actual resizing of the videos is changed, just the styling of the container**
* I updated the storybook for news and commerce to reflect the changes to the `Video` component
* There is a [feature pack PR](https://github.com/WPMedia/arc-themes-feature-pack/pull/465) for the `site-styles` directory

## Acceptance Criteria

The black bars are removed from mobile videos only.

## Test Steps

1. Checkout this branch: `git checkout THEMES-1350-mobile-video-styling`
2. Run fusion with video blocks linked: `npx fusion start -f -l @wpmedia/video-player-block,@wpmedia/lead-art-block,@wpmedia/article-body-block`
3. Open your local PageBuilder instance and create a new page.
    * The layout doesn't matter (if you want to copy me exactly, I used the Right Rail layout and put all of the blocks in the "fullwidth2" section)
    * Set the global content source to `content-api` and set `_id` to "JLIWHMWKYJBNBGNYQDMAUXYGOA". This story has embedded videos and lead art for testing
    * Place a Lead Art block
    * Place an Article Body chain. I set it to lazy load
    * Place a Video Center Player block. Under Configure Content, set the Video Content to `ans-item`, Content Source to `content-api`, and `_id` to "3509db8e-aaea-4264-8efa-b9fe039af027". **Make sure the "Inherit gobal content" checkbox is unchecked!** Under display settings, make the title "Rain on the Road", description "Fall", alert badge "rain", and the video display style "Inline Video." This block will be used to test vertical video.
    * Place another Video Center Player block. Under Configure Content, set the Video Content to `ans-item`, Content Source to `content-api`, and `_id` to "4ae0b7de-dc1c-440a-9655-08eb5bfc81fd". **Make sure the "Inherit gobal content" checkbox is unchecked!** Under display settings, make the title "Horizontal Video", description "Real Madrid flag", alert badge "soccer", and the video display style "Inline Video." This block will be used to test horizontal video.
4. While the device is set to responsive, make sure that all of the videos look correct. If you want, you can resize the page to see how the background changes when the screen becomes skinnier
5. Set the device to a mobile one (I used the Pixel 5) and make sure that the videos have no black bars around them
6. **Optional:** Check storybook
    * Run Storybook `npm run storybook`
    *  Check out the video storybook documentation

## Effect of changes

### Before

#### Desktop

https://github.com/WPMedia/arc-themes-components/assets/103296586/2d715cb3-fd8c-4c3c-9862-47e16afc21f9

#### Mobile

https://github.com/WPMedia/arc-themes-components/assets/103296586/7e61a43e-74c6-4a2c-b210-595fa738c363

### After

#### Desktop

https://github.com/WPMedia/arc-themes-components/assets/103296586/992a1c98-2555-4e06-9ca2-f022212697c6

*This should look exactly the same as the before video*

#### Mobile

https://github.com/WPMedia/arc-themes-components/assets/103296586/2c1487ac-0951-4b95-afe9-845833fc900b

## Dependencies or Side Effects

This PR is dependent on some changes to `arc-themes-feature-pack`. The PR is [here](https://github.com/WPMedia/arc-themes-feature-pack/pull/465).

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1350]: https://arcpublishing.atlassian.net/browse/THEMES-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ