### PR TITLE
DAM-7996

### DIFF
--- a/scripts/style-token-descriptions.json
+++ b/scripts/style-token-descriptions.json
@@ -425,6 +425,9 @@
 		"media-item-fig-caption": {
 			"description": "The styling for the figure caption within the media item component."
 		},
+		"media-item-fig-caption-vertical-video": {
+			"description": "The styling for the figure caption within the media item component when a vertical video is displayed."
+		},
 		"media-item-title": {
 			"description": "The styling for the title text within the media item component."
 		},

--- a/scripts/style-token-descriptions.json
+++ b/scripts/style-token-descriptions.json
@@ -545,6 +545,9 @@
 		},
 		"video-frame": {
 			"description": "The styling for the video frame, which contains the video component and may include controls or other elements."
+		},
+		"vertical-video-frame": {
+			"description": "The styling for the video frame when it's vertical."
 		}
 	}
 }

--- a/src/components/conditional/index.stories.mdx
+++ b/src/components/conditional/index.stories.mdx
@@ -9,7 +9,7 @@ import Conditional from ".";
 
 # Conditional
 
-A component used for conditionally rendering a wrapping component.  If the Condition is met, the component specified will be rendered with the children provided therein.  If the condition is not met, only the children will be rendered.
+A component used for conditionally rendering a wrapping component. If the Condition is met, the component specified will be rendered with the children provided therein. If the condition is not met, only the children will be rendered.
 
 ## Usage
 

--- a/src/components/media-item/STYLE-TOKENS.md
+++ b/src/components/media-item/STYLE-TOKENS.md
@@ -2,10 +2,11 @@
 
 This component provides the following style tokens for customization.
 
-| **Token**              | **Description**                                                                                          |
-| ---------------------- | -------------------------------------------------------------------------------------------------------- |
-| media-item             | The base styling for a media item component, typically used for images or videos with accompanying text. |
-| media-item-fig-caption | The styling for the figure caption within the media item component.                                      |
-| media-item-title       | The styling for the title text within the media item component.                                          |
-| media-item-caption     | The styling for the caption text within the media item component.                                        |
-| media-item-credit      | The styling for the credit text within the media item component.                                         |
+| **Token**                             | **Description**                                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| media-item                            | The base styling for a media item component, typically used for images or videos with accompanying text. |
+| media-item-fig-caption                | The styling for the figure caption within the media item component.                                      |
+| media-item-fig-caption-vertical-video | The styling for the figure caption for vertical videos within the media item component.                  |
+| media-item-title                      | The styling for the title text within the media item component.                                          |
+| media-item-caption                    | The styling for the caption text within the media item component.                                        |
+| media-item-credit                     | The styling for the credit text within the media item component.                                         |

--- a/src/components/media-item/_index.scss
+++ b/src/components/media-item/_index.scss
@@ -10,7 +10,7 @@
 			@include scss.component-properties("media-item-fig-caption-fullscreen");
 		}
 	}
-
+	/* stylelint-disable selector-class-pattern */
 	.c-video__frame:has(.powa-vertical) ~ &__fig-caption {
 		@include scss.component-properties("media-item-fig-caption-vertical-video");
 	}

--- a/src/components/media-item/_index.scss
+++ b/src/components/media-item/_index.scss
@@ -11,6 +11,10 @@
 		}
 	}
 
+	.c-video__frame:has(.powa-vertical) ~ &__fig-caption {
+		@include scss.component-properties("media-item-fig-caption-vertical-video");
+	}
+
 	&__title {
 		@include scss.component-properties("media-item-title");
 	}

--- a/src/components/media-item/index.stories.mdx
+++ b/src/components/media-item/index.stories.mdx
@@ -2,6 +2,7 @@ import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs";
 
 import MediaItem from ".";
 import Image from "../image";
+import Video from "../video";
 
 <Meta title="Components/Media Item" component={MediaItem} />
 
@@ -118,6 +119,22 @@ const MediaItemFeature = () => (
 				caption={"There is a person using a laptop"}
 				src="/computer-user.jpeg"
 				alt="A person sat down using a laptop computer"
+			/>
+		</MediaItem>
+	</Story>
+</Canvas>
+
+** With vertical video **
+
+<Canvas>
+	<Story name="With image">
+		<MediaItem credit="John Doe (Stock Photo)" title={"Person Sitting"}>
+			<Video
+				borderRadius
+				aspectRatio="9:16"
+				embedMarkup={
+					'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+				}
 			/>
 		</MediaItem>
 	</Story>

--- a/src/components/media-item/themes/commerce.json
+++ b/src/components/media-item/themes/commerce.json
@@ -18,6 +18,13 @@
 			}
 		}
 	},
+	"media-item-fig-caption-vertical-video": {
+		"styles": {
+			"default": {
+				"text-align": "center"
+			}
+		}
+	},
 	"media-item-title": {
 		"styles": {
 			"default": {

--- a/src/components/media-item/themes/news.json
+++ b/src/components/media-item/themes/news.json
@@ -18,6 +18,13 @@
 			}
 		}
 	},
+	"media-item-fig-caption-vertical-video": {
+		"styles": {
+			"default": {
+				"text-align": "center"
+			}
+		}
+	},
 	"media-item-fig-caption-fullscreen": {
 		"styles": {
 			"default": {

--- a/src/components/video/STYLE-TOKENS.md
+++ b/src/components/video/STYLE-TOKENS.md
@@ -2,7 +2,8 @@
 
 This component provides the following style tokens for customization.
 
-| **Token**   | **Description**                                                                                                 |
-| ----------- | --------------------------------------------------------------------------------------------------------------- |
-| video       | The base styling for a video component, used for displaying video content.                                      |
-| video-frame | The styling for the video frame, which contains the video component and may include controls or other elements. |
+| **Token**            | **Description**                                                                                                 |
+| -------------------- | --------------------------------------------------------------------------------------------------------------- |
+| video                | The base styling for a video component, used for displaying video content.                                      |
+| video-frame          | The styling for the video frame, which contains the video component and may include controls or other elements. |
+| vertical-video-frame | The styling for the video frame,.                                                                               |

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -15,9 +15,11 @@
 	aspect-ratio: var(--aspect-ratio);
 	// convert to vh via * 1vh
 	max-height: calc(var(--height) * 1vh);
-	max-width: 100%;
-}
 
-.c-video__frame {
-	@include scss.component-properties("video-frame");
+	&__frame {
+		@include scss.component-properties("video-frame");
+		&:has(.powa-vertical) {
+			@include scss.component-properties("vertical-video-frame");
+		}
+	}
 }

--- a/src/components/video/_index.scss
+++ b/src/components/video/_index.scss
@@ -18,6 +18,7 @@
 
 	&__frame {
 		@include scss.component-properties("video-frame");
+		/* stylelint-disable selector-class-pattern */
 		&:has(.powa-vertical) {
 			@include scss.component-properties("vertical-video-frame");
 		}

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -2,8 +2,11 @@ import { useEffect } from "react";
 import PropTypes from "prop-types";
 import EmbedContainer from "react-oembed-container";
 import formatPowaVideoEmbed from "../../utils/format-powa-video-embed";
+import getAspectRatioFromPowa from "../../utils/get-powa-aspect-ratio";
 
 const COMPONENT_CLASS_NAME = "c-video";
+
+const truncate = (num) => Math.trunc(num * 10000) / 10000;
 
 const Video = ({
 	className,
@@ -26,9 +29,12 @@ const Video = ({
 
 	const containerClassNames = [COMPONENT_CLASS_NAME, className].filter((i) => i).join(" ");
 
-	const truncate = (num) => Math.trunc(num * 10000) / 10000;
+	const validAspectRatio = aspectRatio && aspectRatio !== "--";
 
-	const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
+	const [w, h] = validAspectRatio
+		? aspectRatio.split(":")
+		: getAspectRatioFromPowa(embedMarkup).split(":");
+
 	const videoAspectRatio = truncate(h / w);
 
 	const updatedEmbedMarkup = formatPowaVideoEmbed(embedMarkup, {

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -33,7 +33,7 @@ const Video = ({
 
 	const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
 		"aspect-ratio": videoAspectRatio,
-		"border-radius": borderRadius,
+		"border-radius": videoAspectRatio > 1 ? borderRadius : 0,
 	});
 
 	return (
@@ -43,7 +43,7 @@ const Video = ({
 				className={containerClassNames}
 				style={{
 					"--aspect-ratio": truncate(w / h),
-					"--height": viewportPercentage,
+					"--height": videoAspectRatio > 1 ? viewportPercentage : "",
 				}}
 			>
 				{shouldRenderVideoContent ? (

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -33,7 +33,7 @@ const Video = ({
 
 	const updatedEmbedMarkup = formatPowaVideoEmbed(embedMarkup, {
 		"aspect-ratio": videoAspectRatio,
-		"border-radius": videoAspectRatio > 1 ? borderRadius : 0,
+		"border-radius": videoAspectRatio > 1 ? borderRadius : undefined,
 	});
 
 	return (
@@ -43,7 +43,7 @@ const Video = ({
 				className={containerClassNames}
 				style={{
 					"--aspect-ratio": truncate(w / h),
-					"--height": videoAspectRatio > 1 ? viewportPercentage : "",
+					"--height": videoAspectRatio > 1 ? viewportPercentage : 65,
 				}}
 			>
 				{shouldRenderVideoContent ? (

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -5,7 +5,14 @@ import formatPowaVideoEmbed from "../../utils/format-powa-video-embed";
 
 const COMPONENT_CLASS_NAME = "c-video";
 
-const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...rest }) => {
+const Video = ({
+	className,
+	aspectRatio,
+	viewportPercentage,
+	embedMarkup,
+	borderRadius,
+	...rest
+}) => {
 	// only render or call powaboot on client-side
 	const shouldRenderVideoContent = embedMarkup && typeof window !== "undefined";
 
@@ -26,6 +33,7 @@ const Video = ({ className, aspectRatio, viewportPercentage, embedMarkup, ...res
 
 	const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
 		"aspect-ratio": videoAspectRatio,
+		"border-radius": borderRadius,
 	});
 
 	return (
@@ -59,6 +67,8 @@ Video.propTypes = {
 	aspectRatio: PropTypes.string,
 	/* The vertical percentage of the viewport takes up */
 	viewportPercentage: PropTypes.number,
+	/* The vertical percentage of the viewport takes up */
+	borderRadius: PropTypes.number,
 };
 
 export default Video;

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -67,8 +67,8 @@ Video.propTypes = {
 	aspectRatio: PropTypes.string,
 	/* The vertical percentage of the viewport takes up */
 	viewportPercentage: PropTypes.number,
-	/* The vertical percentage of the viewport takes up */
-	borderRadius: PropTypes.number,
+	/* The border radius for the corners of the video */
+	borderRadius: PropTypes.bool,
 };
 
 export default Video;

--- a/src/components/video/index.jsx
+++ b/src/components/video/index.jsx
@@ -31,7 +31,7 @@ const Video = ({
 	const [w, h] = aspectRatio ? aspectRatio.split(":") : [16, 9];
 	const videoAspectRatio = truncate(h / w);
 
-	const embedMarkupWithAspectRatio = formatPowaVideoEmbed(embedMarkup, {
+	const updatedEmbedMarkup = formatPowaVideoEmbed(embedMarkup, {
 		"aspect-ratio": videoAspectRatio,
 		"border-radius": videoAspectRatio > 1 ? borderRadius : 0,
 	});
@@ -47,10 +47,10 @@ const Video = ({
 				}}
 			>
 				{shouldRenderVideoContent ? (
-					<EmbedContainer markup={embedMarkupWithAspectRatio}>
+					<EmbedContainer markup={updatedEmbedMarkup}>
 						<div
 							dangerouslySetInnerHTML={{
-								__html: embedMarkupWithAspectRatio,
+								__html: updatedEmbedMarkup,
 							}}
 						/>
 					</EmbedContainer>

--- a/src/components/video/index.stories.mdx
+++ b/src/components/video/index.stories.mdx
@@ -10,7 +10,9 @@ The `Video` component is a container used to initiate and display a Powa video p
 
 To maximize Core Web Vitals scores, the `aspect-ratio` property can be set to match the `embedMarkup`'s expected data. Please see [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) and [Google's advice](https://web.dev/aspect-ratio/#maintaining-aspect-ratio-with-aspect-ratio) on this pattern.
 
-The `viewportPercentage` property can be used to set the percentage of the vertical viewport that the video should occupy. The default is `65`. This is designed so that the video's aspect ratio and video container maintain the desired aspect-ratio. For a mobile user, this can be helpful to ensure a vertical video does not take up the entire viewport.
+The `viewportPercentage` property can be used to set the percentage of the vertical viewport that the video should occupy. The default is `65` and this property only applies for videos in `9:16`. This is designed so that the video's aspect ratio and video container maintain the desired aspect-ratio. For a mobile user, this can be helpful to ensure a vertical video does not take up the entire viewport.
+
+The `borderRadius` property can be used to round the corners of the video player. The default is `false` and this property only applies for videos in `9:16`. This property maps the `data-border-radius` property from PoWa; The styling is entirely handled by the PoWa player.
 
 ## Usage
 
@@ -37,7 +39,7 @@ const Feature = () => {
 	<Story name="Video Half Vertical Viewport Loading">
 		<Video
 			viewportPercentage={50}
-			aspectRatio="16:9"
+			aspectRatio="9:16"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -51,7 +53,7 @@ const Feature = () => {
 	<Story name="Video Full Vertical Viewport Loading">
 		<Video
 			viewportPercentage={100}
-			aspectRatio="16:9"
+			aspectRatio="9:16"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -65,7 +67,7 @@ const Feature = () => {
 	<Story name="Video One Third Vertical Viewport Loading">
 		<Video
 			viewportPercentage={33.33}
-			aspectRatio="16:9"
+			aspectRatio="9:16"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
@@ -78,15 +80,28 @@ const Feature = () => {
 <Canvas>
 	<Story name="Two videos, different aspect ratios">
 		<Video
-			viewportPercentage={33.33}
 			aspectRatio="4:3"
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.75" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}
 		/>
 		<Video
-			viewportPercentage={33.33}
 			aspectRatio="16:9"
+			embedMarkup={
+				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
+			}
+		/>
+	</Story>
+</Canvas>
+
+** Vertical video with rounded corners **
+
+<Canvas>
+	<Story name="Vertical video with rounded corners with custom viewport percentage">
+		<Video
+			viewportPercentage={80}
+			aspectRatio="9:16"
+			borderRadius
 			embedMarkup={
 				'<div class="powa" id="powa-e924e51b-db94-492e-8346-02283a126943" data-org="corecomponents" data-env="prod" data-uuid="e924e51b-db94-492e-8346-02283a126943" data-aspect-ratio="0.562" data-api="prod"><script src="//d2w3jw6424abwq.cloudfront.net/prod/powaBoot.js?org=corecomponents"></script></div>'
 			}

--- a/src/components/video/index.test.jsx
+++ b/src/components/video/index.test.jsx
@@ -35,9 +35,36 @@ describe("Video", () => {
 		);
 	});
 
-	it("should render container with vertical viewport percentage", () => {
-		const { container } = render(<Video viewportPercentage={50} />);
+	it("should resolve the aspect-ratio from the embed markup if none is provided", () => {
+		window.powaBoot = jest.fn();
+		const { container } = render(
+			<Video embedMarkup="<div class='powa' data-aspect-ratio='0.75'/>" />
+		);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle(
+			"--aspect-ratio: 1.3333"
+		);
+	});
+
+	it("should resolve the aspect-ratio from the embed markup if '--' is provided", () => {
+		window.powaBoot = jest.fn();
+		const { container } = render(
+			<Video aspectRatio="--" embedMarkup="<div class='powa' data-aspect-ratio='0.562'/>" />
+		);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle(
+			"--aspect-ratio: 1.7777"
+		);
+	});
+
+	it("should render container with custom height when it's a 9:16 video", () => {
+		const { container } = render(<Video viewportPercentage={50} aspectRatio="9:16" />);
 		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--height: 50");
+	});
+
+	it("should render container with default height when it's not a 9:16 video", () => {
+		const { container } = render(<Video viewportPercentage={50} aspectRatio="16:9" />);
+		expect(container.querySelector(`.${COMPONENT_CLASS_NAME}`)).toHaveStyle("--height: 65");
 	});
 
 	it("should initiate video and render markup if not empty", () => {
@@ -57,5 +84,25 @@ describe("Video", () => {
 		expect(window.powaBoot).toHaveBeenCalled();
 		expect(container.querySelector(".powa")).not.toBeNull();
 		expect(container.querySelector(".powa")).toHaveAttribute("data-aspect-ratio", "0.75");
+	});
+
+	it("should attach the border-radius attribute in the embed markup when it's a 9:16 video", () => {
+		window.powaBoot = jest.fn();
+		const { container } = render(
+			<Video borderRadius embedMarkup="<div class='powa' data-aspect-ratio='1.7777'/>" />
+		);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(".powa")).not.toBeNull();
+		expect(container.querySelector(".powa")).toHaveAttribute("data-border-radius", "true");
+	});
+
+	it("should not attach the border-radius attribute in the embed markup when it's a not a 9:16 video", () => {
+		window.powaBoot = jest.fn();
+		const { container } = render(
+			<Video borderRadius embedMarkup="<div class='powa' data-aspect-ratio='0.562'/>" />
+		);
+		expect(window.powaBoot).toHaveBeenCalled();
+		expect(container.querySelector(".powa")).not.toBeNull();
+		expect(container.querySelector(".powa")).not.toHaveAttribute("data-border-radius");
 	});
 });

--- a/src/components/video/themes/commerce.json
+++ b/src/components/video/themes/commerce.json
@@ -15,5 +15,12 @@
 				"background-color": "var(--global-black)"
 			}
 		}
+	},
+	"vertical-video-frame": {
+		"styles": {
+			"default": {
+				"background-color": "transparent"
+			}
+		}
 	}
 }

--- a/src/components/video/themes/news.json
+++ b/src/components/video/themes/news.json
@@ -15,5 +15,12 @@
 				"background-color": "var(--global-black)"
 			}
 		}
+	},
+	"vertical-video-frame": {
+		"styles": {
+			"default": {
+				"background-color": "transparent"
+			}
+		}
 	}
 }

--- a/src/utils/format-powa-video-embed/index.js
+++ b/src/utils/format-powa-video-embed/index.js
@@ -1,24 +1,9 @@
-const isEqual = (object1, object2) => {
-	const keys1 = Object.keys(object1);
-	const keys2 = Object.keys(object2);
-	if (keys1.length === keys2.length) {
-		return !keys1.find((key) => object1[key] !== object2[key]);
-	}
-	return false;
-};
-
 const formatPowaVideoEmbed = (embedMarkup, powaFields = {}) => {
 	if (embedMarkup) {
 		// get markup as node to set properties
 		const parser = new DOMParser();
 		const doc = parser.parseFromString(embedMarkup, "text/html");
 		const embedHTMLWithPlayStatus = doc.body;
-		if (
-			isEqual(powaFields, { "aspect-ratio": 0.562 }) ||
-			isEqual(powaFields, { "aspect-ratio": 0.5625 })
-		) {
-			return embedHTMLWithPlayStatus.innerHTML;
-		}
 		const powaFieldEntries = Object.entries(powaFields).filter(
 			([, value]) => typeof value !== "undefined"
 		);

--- a/src/utils/get-powa-aspect-ratio/index.js
+++ b/src/utils/get-powa-aspect-ratio/index.js
@@ -1,0 +1,52 @@
+/**
+ * Function to determine if a number is closer to another one given a delta
+ *
+ * @param n1 Number 1
+ * @param n2 Number 2
+ * @param delta Delta
+ *
+ * @returns Boolean
+ */
+function isNear(n1, n2, delta) {
+	const diff = Math.abs(n1 - n2);
+	return diff <= delta;
+}
+
+/**
+ * Function to resolve aspect ratios using memoized values
+ *
+ * @param aspectRatio Aspect ratio in the form `/\d\.\d+/`
+ *
+ * @returns A string of the form `/\d+:\d+/` representing the aspect ratio in simplest form
+ */
+function resolveAspectRatio(aspectRatio) {
+	if (isNear(0.5625, aspectRatio, 0.001)) return "16:9";
+
+	if (aspectRatio === 1) return "1:1";
+
+	if (aspectRatio === 0.75) return "4:3";
+
+	if (isNear(1.7777, aspectRatio, 0.001)) return "9:16";
+
+	return "16:9";
+}
+
+/**
+ * Helper function to resolve the aspect-ratio from a powa tag
+ *
+ * @param embedHTML HTML string with PoWa tag
+ *
+ * @returns A string of the form `/\d+:\d+/` representing the aspect ratio in simplest form
+ */
+const getAspectRatioFromPowa = (embedHTML) => {
+	if (embedHTML) {
+		const parser = new DOMParser();
+		const doc = parser.parseFromString(embedHTML, "text/html");
+		const dataset = doc.body.querySelector(".powa")?.dataset;
+		const aspectRatio = resolveAspectRatio(Number(dataset.aspectRatio));
+		return aspectRatio;
+	}
+	return "16:9";
+};
+
+export default getAspectRatioFromPowa;

--- a/src/utils/get-powa-aspect-ratio/index.test.js
+++ b/src/utils/get-powa-aspect-ratio/index.test.js
@@ -1,0 +1,34 @@
+import getAspectRatioFromPowa from "./index";
+
+describe("Should resolve the aspect ratio from the html tag ", () => {
+	it("resolves 16:9 aspect ratio", () => {
+		const powaTag =
+			'<div class="powa" id="powa-44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-org="themesinternal" data-env="prod" data-uuid="44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-aspect-ratio="0.562" data-api="prod"></div>';
+		const aspectRatio = getAspectRatioFromPowa(powaTag);
+		expect(aspectRatio).toEqual("16:9");
+	});
+	it("resolves 9:16 aspect ratio", () => {
+		const powaTag =
+			'<div class="powa" id="powa-44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-org="themesinternal" data-env="prod" data-uuid="44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-aspect-ratio="1.778" data-api="prod"></div>';
+		const aspectRatio = getAspectRatioFromPowa(powaTag);
+		expect(aspectRatio).toEqual("9:16");
+	});
+	it("resolves 4:3 aspect ratio", () => {
+		const powaTag =
+			'<div class="powa" id="powa-44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-org="themesinternal" data-env="prod" data-uuid="44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-aspect-ratio="0.75" data-api="prod"></div>';
+		const aspectRatio = getAspectRatioFromPowa(powaTag);
+		expect(aspectRatio).toEqual("4:3");
+	});
+	it("resolves 1:1 aspect ratio", () => {
+		const powaTag =
+			'<div class="powa" id="powa-44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-org="themesinternal" data-env="prod" data-uuid="44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-aspect-ratio="1" data-api="prod"></div>';
+		const aspectRatio = getAspectRatioFromPowa(powaTag);
+		expect(aspectRatio).toEqual("1:1");
+	});
+	it("defaults to 16:9 if no aspect ratio is set", () => {
+		const powaTag =
+			'<div class="powa" id="powa-44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-org="themesinternal" data-env="prod" data-uuid="44fd9ccd-b70c-44c1-a493-3cc296698e5e" data-api="prod"></div>';
+		const aspectRatio = getAspectRatioFromPowa(powaTag);
+		expect(aspectRatio).toEqual("16:9");
+	});
+});


### PR DESCRIPTION
## Ticket
- [DAM-7996](https://arcpublishing.atlassian.net/browse/DAM-7996)

## Description
This PR is part of the effort of DAM to give an improved experience in vertical videos across Arc products. it's summarized with this changes:

### Video
- `viewportPercentage` applies only if the video is in the 9:16 aspect ratio.
- New `borderRadius` prop is introduced to round the corners of the player. The styling is applied from PoWa and applies only if the video is in the 9:16 aspect ratio.
- `--` and `undefined` values  in `aspectRatio` prop are considered invalid.
- `getAspectRatioFromPowa` is introduced to solve aspect-ratio from powa tag.
- Introduces `vertical-video-frame` style token to apply custom styling in `.c-video__frame` element when vertical videos are displayed.

### Media Item
- Introduces `media-item-fig-caption-vertical-video` style token to apply custom styling in `c-media-item__fig-caption` element when vertical videos are displayed.


## Acceptance Criteria
- Videos in 9:16 format have to have a transparent background in their block.
- Captions have to align at the center of the block when video in 9:16 format exists.
- viewPercentage and borderRadius are props that only applies for videos in 9:16 format.

## Test Steps

1. Checkout branch - `git checkout DAM-7996`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Check out the video storybook documentation

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[DAM-7996]: https://arcpublishing.atlassian.net/browse/DAM-7996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ