### PR TITLE
THEMES-1538: Move useIdentity hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ import getPromoType from "./src/utils/get-promo-type";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
 import handleFetchError from "./src/utils/handle-fetch-error";
 import handleRedirect from "./src/utils/handle-redirect";
+import useIdentity from "./src/utils/hooks/use-identity";
 import useInterval from "./src/utils/hooks/use-interval";
 import usePhrases from "./src/utils/hooks/use-phrases";
 import imageANSToImageSrc from "./src/utils/image-ans-to-image-src";
@@ -95,6 +96,7 @@ export {
 	serialJoin,
 	signImagesInANSObject,
 	Stack,
+	useIdentity,
 	useInterval,
 	usePhrases,
 	Video,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
+        "@arc-publishing/sdk-identity": "^1.79.0",
         "@wpmedia/timezone": "^1.1.2",
         "dom-parser": "^0.1.6",
         "lazy-child": "^0.3.1",
@@ -96,6 +97,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@arc-publishing/sdk-identity": {
+      "version": "1.79.0",
+      "resolved": "https://registry.npmjs.org/@arc-publishing/sdk-identity/-/sdk-identity-1.79.0.tgz",
+      "integrity": "sha512-eblhb/AMa2uKr3/sWphlonIw5gKrz2KigUYnQDU2riWZn9Z+EECmQsbpbZbkWGDaTXrtkEX3DRqBIPJsPaEsXg==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@aw-web-design/x-default-browser": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "stylelint-no-unsupported-browser-features": "^7.0.0"
   },
   "dependencies": {
+    "@arc-publishing/sdk-identity": "^1.79.0",
     "@wpmedia/timezone": "^1.1.2",
     "dom-parser": "^0.1.6",
     "lazy-child": "^0.3.1",

--- a/src/utils/hooks/use-identity/index.js
+++ b/src/utils/hooks/use-identity/index.js
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import Identity from "@arc-publishing/sdk-identity";
+import { useFusionContext } from "fusion:context";
+import getProperties from "fusion:properties";
+
+/**
+ * getSignedInIdentity: Helper function to determine what account user is logged in with.
+ * @param user
+ * @returns entry in the identities array that has the most recent login date
+ */
+const getSignedInIdentity = (user) =>
+	user?.identities?.reduce((prev, current) =>
+		prev.lastLoginDate > current.lastLoginDate ? prev : current
+	) || null;
+
+const useIdentity = () => {
+	const { arcSite } = useFusionContext();
+	const { api } = getProperties(arcSite);
+
+	const [isInit, setIsInit] = useState(!!Identity.apiOrigin);
+
+	if (!isInit && arcSite && api?.identity?.origin) {
+		Identity.options({ apiOrigin: api.identity.origin });
+		setIsInit(true);
+	}
+
+	return {
+		Identity,
+		isInitialized: isInit,
+		getSignedInIdentity,
+	};
+};
+
+export default useIdentity;

--- a/src/utils/hooks/use-identity/index.test.js
+++ b/src/utils/hooks/use-identity/index.test.js
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import IdentityObject from "@arc-publishing/sdk-identity";
+import useIdentity from ".";
+
+jest.mock("@arc-publishing/sdk-identity", () => ({
+	__esModule: true,
+	default: {
+		apiOrigin: "",
+		options: jest.fn(),
+	},
+}));
+
+jest.mock("fusion:properties", () =>
+	jest.fn(() => ({
+		// arcSite
+		api: {
+			identity: {
+				origin: "http://origin/",
+			},
+		},
+	}))
+);
+
+jest.mock("fusion:context", () => ({
+	__esModule: true,
+	useFusionContext: () => ({
+		arcSite: "Test Site",
+	}),
+}));
+
+describe("Identity useIdentity Hook", () => {
+	it("returns itself and changes the option to http://origin", () => {
+		const Test = () => {
+			const { Identity } = useIdentity();
+			expect(Identity).toBe(IdentityObject);
+			return <div />;
+		};
+
+		render(<Test />);
+		expect(IdentityObject.options).toHaveBeenLastCalledWith({
+			apiOrigin: "http://origin/",
+		});
+	});
+
+	it("initializes", () => {
+		const testInitialization = jest.fn();
+
+		const Test = () => {
+			const { isInitialized } = useIdentity();
+			testInitialization(isInitialized);
+			return <div />;
+		};
+
+		render(<Test />);
+
+		expect(testInitialization).toHaveBeenCalledWith(false);
+		expect(testInitialization).toHaveBeenLastCalledWith(true);
+	});
+
+	it("The getSignedInIdentity utility function returns the current signed in identity", () => {
+		const testUser = {
+			identities: [
+				{
+					userName: "93284374387433",
+					passwordReset: false,
+					type: "Facebook",
+					lastLoginDate: 1639164734000,
+					locked: false,
+				},
+				{
+					userName: "106487204473538668210",
+					passwordReset: false,
+					type: "Google",
+					lastLoginDate: 1639164736000,
+					locked: false,
+				},
+			],
+		};
+		const Test = () => {
+			const { getSignedInIdentity } = useIdentity();
+			const getCurrent = getSignedInIdentity(testUser);
+			return <div>{getCurrent.type}</div>;
+		};
+		render(<Test />);
+		expect(screen.getByText("Google")).toBeInTheDocument();
+	});
+
+	it("The getSignedInIdentity utility function returns the current signed in identity when timestamps are not in order", () => {
+		const testUser = {
+			identities: [
+				{
+					userName: "93284374387433",
+					passwordReset: false,
+					type: "Facebook",
+					lastLoginDate: 1639164736000,
+					locked: false,
+				},
+				{
+					userName: "106487204473538668210",
+					passwordReset: false,
+					type: "Google",
+					lastLoginDate: 1639164734000,
+					locked: false,
+				},
+			],
+		};
+
+		const Test = () => {
+			const { getSignedInIdentity } = useIdentity();
+			const getCurrent = getSignedInIdentity(testUser);
+			return <div>{getCurrent.type}</div>;
+		};
+		render(<Test />);
+		expect(screen.getByText("Facebook")).toBeInTheDocument();
+	});
+});

--- a/src/utils/hooks/use-identity/index.test.js
+++ b/src/utils/hooks/use-identity/index.test.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import "@testing-library/jest-dom/extend-expect";
 import IdentityObject from "@arc-publishing/sdk-identity";
 import useIdentity from ".";
 


### PR DESCRIPTION
## Ticket

- [THEMES-1538](https://arcpublishing.atlassian.net/browse/THEMES-1538)

## Description

This PR moves the shared useIdentity hook into Themes components.

## Acceptance Criteria

Hook is in Themes components

## Test Steps

See blocks PR: https://github.com/WPMedia/arc-themes-blocks/pull/1799

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1538]: https://arcpublishing.atlassian.net/browse/THEMES-1538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ