### PR TITLE
THEMES-1400: Resizer URL bug

### DIFF
--- a/src/components/image/index.test.jsx
+++ b/src/components/image/index.test.jsx
@@ -282,7 +282,7 @@ describe("Image", () => {
 			<Image
 				ansImage={{
 					_id: "123",
-					url: "test-image.jpg",
+					url: "http://image-host.com/test-image.jpg",
 					auth: {
 						2: "secret",
 					},

--- a/src/utils/image-ans-to-image-src/index.js
+++ b/src/utils/image-ans-to-image-src/index.js
@@ -9,16 +9,12 @@ const imageANSToImageSrc = (data) => {
 	const { _id: id, auth, url } = data || {};
 	if (url) {
 		if (id) {
-			const urlParts = url.split(".");
-			if (urlParts.length !== 1) {
-				const fileExtension = urlParts.pop();
-				if (fileExtension.includes(id)) {
-					// This can happen when there is no file extension on the image URL.
-					// Return only the ID forced to be a string.
-					return `${id}`;
-				}
-				return `${id}.${fileExtension}`;
+			const fileExtension = url.match(/\.\w{3,4}$/);
+			if (fileExtension) {
+				return `${id}${fileExtension[0]}`;
 			}
+			// Return the id as a string if no file extension is found.
+			return `${id}`
 		} else if (auth) {
 			return encodeURIComponent(url);
 		}

--- a/src/utils/image-ans-to-image-src/index.js
+++ b/src/utils/image-ans-to-image-src/index.js
@@ -11,7 +11,13 @@ const imageANSToImageSrc = (data) => {
 		if (id) {
 			const urlParts = url.split(".");
 			if (urlParts.length !== 1) {
-				return `${id}.${urlParts.pop()}`;
+				const fileExtension = urlParts.pop();
+				if (fileExtension.includes(id)) {
+					// This can happen when there is no file extension on the image URL.
+					// Return only the ID forced to be a string.
+					return `${id}`;
+				}
+				return `${id}.${fileExtension}`;
 			}
 		} else if (auth) {
 			return encodeURIComponent(url);

--- a/src/utils/image-ans-to-image-src/index.test.js
+++ b/src/utils/image-ans-to-image-src/index.test.js
@@ -7,6 +7,10 @@ describe("imageANSToImageSrc", () => {
 		expect(imageANSToImageSrc({ _id: 321, url: "test.test.jpeg" })).toBe("321.jpeg");
 	});
 
+	it("return image src without ext", () => {
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/123" })).toBe("123");
+	});
+
 	it("return image src as encoded url when no _id but an auth exists", () => {
 		expect(imageANSToImageSrc({ url: "http://image.com/test.jpg", auth: { 1: "123" } })).toBe(
 			encodeURIComponent("http://image.com/test.jpg")

--- a/src/utils/image-ans-to-image-src/index.test.js
+++ b/src/utils/image-ans-to-image-src/index.test.js
@@ -2,9 +2,9 @@ import imageANSToImageSrc from ".";
 
 describe("imageANSToImageSrc", () => {
 	it("return image src with ext", () => {
-		expect(imageANSToImageSrc({ _id: 123, url: "test.jpg" })).toBe("123.jpg");
-		expect(imageANSToImageSrc({ _id: 123, url: "test.test.jpg" })).toBe("123.jpg");
-		expect(imageANSToImageSrc({ _id: 321, url: "test.test.jpeg" })).toBe("321.jpeg");
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/test.test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 321, url: "http://image.com/test.test.jpeg" })).toBe("321.jpeg");
 	});
 
 	it("return image src without ext", () => {
@@ -18,7 +18,6 @@ describe("imageANSToImageSrc", () => {
 	});
 
 	it("will return null if incorrect ANS data", () => {
-		expect(imageANSToImageSrc({ _id: 123, url: "testjpg" })).toBe(null);
 		expect(imageANSToImageSrc({ _id: 123 })).toBe(null);
 		expect(imageANSToImageSrc({ url: "testjpg" })).toBe(null);
 		expect(imageANSToImageSrc()).toBe(null);


### PR DESCRIPTION
## Ticket

- [THEMES-1400](https://arcpublishing.atlassian.net/browse/THEMES-1400)

## Description

This PR corrects a bug that occurs when a photo center URL does not have a file extension.

## Acceptance Criteria

Images load correctly

## Test Steps

1. Checkout branch - `git checkout THEMES-1400`
2. Update dependencies - `npm i`
3. Run Irish News bundle locally with Themes components linked.
4. Visit http://localhost/news/northern-ireland/prosecutors-in-belfast-receive-files-in-cross-border-murder-investigation-court-hears-66JVARQSTBDA7LJCXTKI54WHSE/?_website=irishnews
5. The lead art image and all other images should load.

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed relevant documentation has been updated/added.
- [ ] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-1400]: https://arcpublishing.atlassian.net/browse/THEMES-1400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ