### PR TITLE
added back text direction logic

### DIFF
--- a/src/scss/root/_index.scss
+++ b/src/scss/root/_index.scss
@@ -216,6 +216,10 @@ $component-map: get-all-component-definitions($tokens, $breakpoints);
 	}
 }
 
+*[dir="rtl"] {
+	--text-direction: -1;
+}
+
 body {
 	@include component-properties("body");
 }


### PR DESCRIPTION
## Description

Added variable for use in transformations that is equal to 1 if dir="ltr", and -1 if dir="rtl" . This variable can be used in calculations for transformations, such as the side-drawer slide out action

This code was removed by this PR: https://github.com/WPMedia/arc-themes-components/commit/bb92a0b8f2e231c719d42f3caf898cce880783be#diff-7b2f454623352de602d573c60ad759f97d0d125f629901c54ea220aec691617e 

## Acceptance Criteria

_copy from ticket_

## Test Steps

1. Checkout branch - `git checkout text-direction-fix`
2. Update dependencies - `npm i`
3. Run Fusion with the components repo linked (blocks do not need to be linked since they are already up to date) `npx fusion start -f -l`
4. Make sure the flyout menu behavior is correct

## Author Checklist

_The author of the PR should fill out the following sections to ensure this PR is ready for review._

- [ ] Confirmed all the test steps a reviewer will follow above are working.
- [ ] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [ ] Confirmed relevant documentation has been updated/added.
- [ ] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**
