### PR TITLE
Removed timezone package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,10 @@
     "": {
       "name": "@wpmedia/arc-themes-components",
       "version": "0.0.4-arc-themes-release-version-2-1-3.9",
-      "hasInstallScript": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "@arc-publishing/sdk-identity": "^1.79.0",
         "@storybook/addon-docs": "^7.6.4",
-        "@wpmedia/timezone": "^1.1.2",
         "dom-parser": "^0.1.6",
         "eslint-plugin-testing-library": "^6.2.0",
         "lazy-child": "^0.3.1",
@@ -6411,12 +6409,6 @@
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "node_modules/@wpmedia/timezone": {
-      "version": "1.1.2",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/timezone/1.1.2/4c7845ae0774bed86ce2136af1537afa0634332a",
-      "integrity": "sha512-rRwGeolQP0+0Psx5Q8FPMndQrodWHaqhxoylO24Vb9SCsFAxesNBHw7Bq7xNE+bWocV35Ze2WUw9LybbzfUF9w==",
-      "license": "MIT"
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
   "dependencies": {
     "@arc-publishing/sdk-identity": "^1.79.0",
     "@storybook/addon-docs": "^7.6.4",
-    "@wpmedia/timezone": "^1.1.2",
     "dom-parser": "^0.1.6",
     "eslint-plugin-testing-library": "^6.2.0",
     "lazy-child": "^0.3.1",


### PR DESCRIPTION
Quick PR to remove the unused `@wpmedia/timezone` package.