### PR TITLE
THEMES-891: add helper function for focal point

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ import formatURL from "./src/utils/format-url";
 import getAspectRatio from "./src/utils/get-aspect-ratio";
 
 // the following are ordered by dependency
+import getFocalFromANS from "./src/utils/get-focal-from-ans";
 import getImageFromANS from "./src/utils/get-image-from-ans";
 import getPromoType from "./src/utils/get-promo-type";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
@@ -67,6 +68,7 @@ export {
 	formatSocialURL,
 	formatURL,
 	getAspectRatio,
+	getFocalFromANS,
 	getImageFromANS,
 	getPromoType,
 	getVideoFromANS,

--- a/src/utils/get-focal-from-ans/getFocalFromANS.test.js
+++ b/src/utils/get-focal-from-ans/getFocalFromANS.test.js
@@ -1,0 +1,62 @@
+import getFocalFromANS from "./index";
+
+const mockImageWithFocal = {
+	_id: "P3V3THIJPVGUBLRIIYWKFHZTKA",
+	type: "image",
+	url: "foo.jpg",
+	focal_point: {
+		x: "159",
+		y: "823",
+	},
+};
+
+const mockImageWithIncompleteFocalX = {
+	_id: "P3V3THIJPVGUBLRIIYWKFHZTKA",
+	type: "image",
+	url: "foo.jpg",
+	focal_point: {
+		x: "159",
+	},
+};
+
+const mockImageWithIncompleteFocalY = {
+	_id: "P3V3THIJPVGUBLRIIYWKFHZTKA",
+	type: "image",
+	url: "foo.jpg",
+	focal_point: {
+		y: "823",
+	},
+};
+
+const mockImageWithoutFocal = {
+	_id: "GH3BDATX7FBZ7DSPPZFD5DPFJM",
+	type: "image",
+	url: "bar.jpg",
+};
+
+describe("getImageFromANS()", () => {
+	it("returns the default value", () => {
+		const value = getFocalFromANS(null);
+		expect(value).toEqual({ smart: true });
+	});
+
+	it("returns the focal point", () => {
+		const value = getFocalFromANS(mockImageWithFocal);
+		expect(value).toEqual({ focal: "159,823" });
+	});
+
+	it("returns the default value when image has no focal point", () => {
+		const value = getFocalFromANS(mockImageWithoutFocal);
+		expect(value).toEqual({ smart: true });
+	});
+
+	it("returns the default value when image has only the x focal point", () => {
+		const value = getFocalFromANS(mockImageWithIncompleteFocalX);
+		expect(value).toEqual({ smart: true });
+	});
+
+	it("returns the default value when image has only the y focal point", () => {
+		const value = getFocalFromANS(mockImageWithIncompleteFocalY);
+		expect(value).toEqual({ smart: true });
+	});
+});

--- a/src/utils/get-focal-from-ans/index.js
+++ b/src/utils/get-focal-from-ans/index.js
@@ -1,0 +1,11 @@
+const getFocalFromANS = (ansImage) => {
+	if (ansImage?.focal_point) {
+		const { x, y } = ansImage.focal_point;
+		if (x && y) {
+			return { focal: `${x},${y}` };
+		}
+	}
+	return { smart: true };
+};
+
+export default getFocalFromANS;


### PR DESCRIPTION
## Ticket

- [THEMES-891](https://arcpublishing.atlassian.net/browse/THEMES-891)

## Description

This PR adds in a helper function, and tests, for getting the focal point from an image ANS object. This needs to be merged in first so the blocks repo can be updated to use the correct version of the `@wpmedia/arc-themes-components` package.

## Acceptance Criteria

- If there is no focal point, then the smart crop is maintained

## Test Steps

1. Checkout branch - `git checkout THEMES-891`
2. Update dependencies - `npm i`
3. Run `npm run test`
4. All tests should pass.
5. This is just for the helper function, the blocks repo will implement the focal point handling and the full test instructions will be in that future PR.

## Author Checklist

- [x] Confirmed all the test steps a reviewer will follow above are working.
- [x] Ran this code locally and checked that there are not any unintended side effects. For example, that a CSS selector is scoped only to a particular block.
- [x] Confirmed relevant documentation has been updated/added.
- [x] Add label - **ready for review** when the pull request is ready for someone to begin reviewing

## Reviewer Checklist

_The reviewer of the PR should copy-paste this template into the review comments on review._

- [ ] All GitHub Actions pass
- [ ] Ran the code locally based on the test instructions.
- [ ] Checked Chromatic for Storybook changes, accepted the updates if acceptable
- [ ] Looked to see that the new or changed code has code coverage, specifically. We want the global code coverage to keep on going up with targeted testing.
- [ ] Approve and Add label - **ready to merge** if you are happy with the pull request
- [ ] Want another reviewer? Add the label **additional review**


[THEMES-891]: https://arcpublishing.atlassian.net/browse/THEMES-891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ