### PR TITLE
ACS-29041: Define grid cell dimensions

### DIFF
--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -6,6 +6,8 @@
 
 	display: grid;
 	grid-template-areas: "controls" "carousel" "indicators";
+	grid-template-columns: 100%;
+	grid-template-rows: min-content;
 	overflow: hidden;
 	word-break: break-word;
 

--- a/src/components/carousel/_index.scss
+++ b/src/components/carousel/_index.scss
@@ -7,7 +7,6 @@
 	display: grid;
 	grid-template-areas: "controls" "carousel" "indicators";
 	grid-template-columns: 100%;
-	grid-template-rows: min-content;
 	overflow: hidden;
 	word-break: break-word;
 


### PR DESCRIPTION
This fixes an issue with the carousel grid items displaying too wide because there was no column restraint.

## Description

#### Jira Ticket: [ACS-29041](https://arcpublishing.atlassian.net/browse/ACS-29041)

The Carousel grid did not have constraints so the cell width was stretching to 100% track width instead of cell width.

## Test Steps

You can see the effect on https://irishnews.arcpublishing.com/pagebuilder/editor/curate/?p=pdF0WLPndEIM5qo7u&v=vNcycmPnRpIM5qo7u by adding `grid-template-columns: 100%;` to the `.c-carousel` class.  You may do additional testing, but I believe this is not breaking in any other ways.


[ACS-29041]: https://arcpublishing.atlassian.net/browse/ACS-29041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ