### PR TITLE
THEMES-1916: Add Additional author object image type

### DIFF
--- a/src/utils/sign-images-in-ans-object/index.js
+++ b/src/utils/sign-images-in-ans-object/index.js
@@ -11,6 +11,16 @@ const transformAuthorImages = (value) => {
 		};
 	}
 
+	if (type === "author" && image?.match(/^https?:\/\/(?:[\w\d_\-]+\.?)+\/?.*$/i)) {
+		return {
+			...value,
+			ansImage: {
+				type: "image",
+				url: image,
+			},
+		};
+	}
+
 	if (authors.length > 0 && typeof authors[0].image === "string") {
 		return {
 			...value,

--- a/src/utils/sign-images-in-ans-object/index.js
+++ b/src/utils/sign-images-in-ans-object/index.js
@@ -11,7 +11,7 @@ const transformAuthorImages = (value) => {
 		};
 	}
 
-	if (type === "author" && image?.match(/^https?:\/\/(?:[\w\d_\-]+\.?)+\/?.*$/i)) {
+	if (type === "author" && image?.match(/^https?:\/\/(?:[\w\d_-]+\.?)+\/?.*$/i)) {
 		return {
 			...value,
 			ansImage: {

--- a/src/utils/sign-images-in-ans-object/index.test.js
+++ b/src/utils/sign-images-in-ans-object/index.test.js
@@ -245,4 +245,19 @@ describe("Sign Images In ANS Object", () => {
 			"545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e45",
 		);
 	});
+
+	it("returns the correct ansImage format for authors with image url strings", async () => {
+		const signIt = signImagesInANSObject(cachedCall, fetcher, 2);
+
+		const { data: signedData } = await signIt({
+			data: {
+				image: "https://s3.amazonaws.com/arc-authors/themesinternal/author-image.png",
+				type: "author",
+			},
+		});
+
+		expect(signedData.ansImage.auth[2]).toBe(
+			"545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e44",
+		);
+	});
 });


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1916](https://arcpublishing.atlassian.net/browse/THEMES-1916)

Updates for the signing service for author images with the "image" key being a url.

## Test Steps

1. Checkout this branch - `git checkout themes-1916`
2. Update dependencies - `npm i`
3. Run Storybook `npm run test`


[THEMES-1916]: https://arcpublishing.atlassian.net/browse/THEMES-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ