### PR TITLE
Re-added null value check

### DIFF
--- a/src/utils/sign-images-in-ans-object/index.js
+++ b/src/utils/sign-images-in-ans-object/index.js
@@ -53,6 +53,9 @@ const signImagesInANSObject =
 		const replacements = new Set();
 
 		const stringData = JSON.stringify(data, (key, value) => {
+			if (value === null) {
+				return value;
+			}
 			const { _id, type, auth, url } = value;
 			if (!auth?.[resizerAppVersion] && type === "image") {
 				replacements.add(_id || url);

--- a/src/utils/sign-images-in-ans-object/index.test.js
+++ b/src/utils/sign-images-in-ans-object/index.test.js
@@ -285,4 +285,19 @@ describe("Sign Images In ANS Object", () => {
 
 		expect(signedData).toMatchObject(data);
 	});
+
+	it("does not fail when null values are present", async () => {
+		const signIt = signImagesInANSObject(cachedCall, fetcher, 2);
+
+		const { data: signedData } = await signIt({
+			data: {
+				...data,
+				testKey: null,
+			},
+		});
+
+		expect(cachedCall).toHaveBeenCalledTimes(3);
+
+		expect(signedData).toMatchObject(data);
+	});
 });


### PR DESCRIPTION
## Description

Added back in a check for null values in the `signImagesInANSObject` utility. Also added a test for the observed bug.

## Test Steps

1. Checkout this branch - `git checkout fix-sign-images-null-handling`
2. Update dependencies - `npm i`
3. Run Fusion with components linked `npx fusion start`
4. Test a variety of stories using the `content-api` content source in the PageBuilder debugger.
    - The ID of one story that was experiencing the issue is `VNYFD6L5D5EANF7ANLZMG62TQI`
5. Content should fetch and the ANS should appear.
