### PR TITLE
THEMES-1906: Helper for manually entered image URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ import getAspectRatio from "./src/utils/get-aspect-ratio";
 // the following are ordered by dependency
 import getFocalFromANS from "./src/utils/get-focal-from-ans";
 import getImageFromANS from "./src/utils/get-image-from-ans";
+import getManualImageID from "./src/utils/get-manual-image-id";
 import getPromoType from "./src/utils/get-promo-type";
 import getVideoFromANS from "./src/utils/get-video-from-ans";
 import handleFetchError from "./src/utils/handle-fetch-error";
@@ -74,6 +75,7 @@ export {
 	getAspectRatio,
 	getFocalFromANS,
 	getImageFromANS,
+	getManualImageID,
 	getPromoType,
 	getVideoFromANS,
 	Grid,

--- a/src/utils/get-manual-image-id/getManualImageID.test.js
+++ b/src/utils/get-manual-image-id/getManualImageID.test.js
@@ -1,0 +1,36 @@
+import getManualImageID from ".";
+
+describe("getManualImageID()", () => {
+	it("returns default value", () => {
+		const manualImageId = getManualImageID();
+		expect(manualImageId).toBe("");
+	});
+
+	it("returns the image id from a cloudfront hosted Photo Center URL without an extension", () => {
+		const imageID = "ABC123DEF456GHI789ABC123DE";
+		const imageURL = `https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/${imageID}`;
+		const manualImageId = getManualImageID(imageURL);
+		expect(manualImageId).toBe(imageID);
+	});
+
+	it("returns the image id from a cloudfront hosted Photo Center URL with a 3 character extension", () => {
+		const imageID = "ABC123DEF456GHI789ABC123DE";
+		const imageURL = `https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/${imageID}.jpg`;
+		const manualImageId = getManualImageID(imageURL);
+		expect(manualImageId).toBe(imageID);
+	});
+
+	it("returns the image id from a cloudfront hosted Photo Center URL with a 4 character extension", () => {
+		const imageID = "ABC123DEF456GHI789ABC123DE";
+		const imageURL = `https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/${imageID}.jpeg`;
+		const manualImageId = getManualImageID(imageURL);
+		expect(manualImageId).toBe(imageID);
+	});
+
+	it("returns default value if resized image flag is true", () => {
+		const imageID = "ABC123DEF456GHI789ABC123DE";
+		const imageURL = `https://cloudfront-us-east-1.images.arcpublishing.com/sandbox.themesinternal/${imageID}.jpeg`;
+		const manualImageId = getManualImageID(imageURL, true);
+		expect(manualImageId).toBe("");
+	});
+});

--- a/src/utils/get-manual-image-id/index.js
+++ b/src/utils/get-manual-image-id/index.js
@@ -1,7 +1,8 @@
 const getManualImageID = (imageURL, isResizedImage = false) => {
 	let manualImageId = "";
 	if (!isResizedImage && imageURL) {
-		const cloudfrontRegex = /cloudfront.*images.arcpublishing.*\/([\w]{26})(?:$|\.[\w]{3,4})/;
+		const cloudfrontRegex =
+			/^https:\/\/cloudfront.*images\.arcpublishing.*\/(\w{26})(?:$|\.\w{3,4})/;
 		const matches = imageURL.match(cloudfrontRegex);
 		manualImageId = Array.isArray(matches) && matches.length >= 2 ? matches[1] : "";
 	}

--- a/src/utils/get-manual-image-id/index.js
+++ b/src/utils/get-manual-image-id/index.js
@@ -1,0 +1,11 @@
+const getManualImageID = (imageURL, isResizedImage = false) => {
+	let manualImageId = "";
+	if (!isResizedImage && imageURL) {
+		const cloudfrontRegex = /cloudfront.*images.arcpublishing.*\/([\w]{26})(?:$|\.[\w]{3,4})/;
+		const matches = imageURL.match(cloudfrontRegex);
+		manualImageId = Array.isArray(matches) && matches.length >= 2 ? matches[1] : "";
+	}
+	return manualImageId;
+};
+
+export default getManualImageID;

--- a/src/utils/get-manual-image-id/index.js
+++ b/src/utils/get-manual-image-id/index.js
@@ -2,7 +2,7 @@ const getManualImageID = (imageURL, isResizedImage = false) => {
 	let manualImageId = "";
 	if (!isResizedImage && imageURL) {
 		const cloudfrontRegex =
-			/^https:\/\/cloudfront.*images\.arcpublishing.*\/(\w{26})(?:$|\.\w{3,4})/;
+			/^https:\/\/cloudfront.{1,50}images\.arcpublishing\.com\/.{1,150}\/(\w{26})(?:$|\.\w{3,4})/;
 		const matches = imageURL.match(cloudfrontRegex);
 		manualImageId = Array.isArray(matches) && matches.length >= 2 ? matches[1] : "";
 	}


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1906](https://arcpublishing.atlassian.net/browse/THEMES-1906)

Adds helper for extracting the photo center image ID from cloudfront URLs. Includes a parameter to skip the regex match if the calling block already determined the image has everything needed for the resizer.

## Test Steps

1. Checkout this branch - `git checkout THEMES-1906`
2. Update dependencies - `npm i`
3. See blocks PR (https://github.com/WPMedia/arc-themes-blocks/pull/2162) for further instructions.


[THEMES-1906]: https://arcpublishing.atlassian.net/browse/THEMES-1906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ