### PR TITLE
THEMES-1864: Button styling fix

### DIFF
--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -1,4 +1,4 @@
-@use "../../scss.scss" with (
+@use "../../scss" with (
 	$breakpoints: (
 		"default": "min-width: 0",
 		"desktop": "min-width: 48rem",
@@ -4460,9 +4460,12 @@
 				),
 				"button-default": (
 					"background-color": var(--global-white),
-					"border-color": var(--global-neutral-7),
+					"border-color": var(--text-color),
 					"border-width": var(--global-border-width-1),
-					"color": var(--global-neutral-7),
+					"color": var(--text-color),
+				),
+				"button-default-hover": (
+					"color": var(--color-primary-hover),
 				),
 				"button-large": (
 					"font-size": var(--body-font-size),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -4502,10 +4502,7 @@
 				),
 				"button-secondary": (
 					"background-color": var(--global-white),
-					"color": var
-						(
-							--global-black,
-						),
+					"color": var(--text-color),
 				),
 				"button-secondary-hover": (
 					"background-color": var(--color-primary-hover),

--- a/.storybook/themes/news.scss
+++ b/.storybook/themes/news.scss
@@ -257,6 +257,67 @@
 					"padding-inline-start": var(--global-spacing-4),
 					"padding-inline-end": var(--global-spacing-4),
 				),
+				"account-management-social-signon-button-connect": (
+					"background-color": var(--global-black),
+				),
+				"account-management-social-signon-button-connected": (
+					"position": absolute,
+					"transform": translatey(175%),
+					"background": var(--global-white),
+					"font-size": var(--global-font-size-3),
+					"padding-inline-end": var(--global-spacing-1),
+					"color": var(--global-green-5),
+					"components": (
+						"icon": (
+							"margin-inline-start": var(--global-spacing-1),
+							"margin-inline-end": var(--global-spacing-1),
+							"fill": var(--global-green-5),
+							"block-size": var(--global-spacing-4),
+							"inline-size": var(--global-spacing-4),
+						),
+					),
+				),
+				"account-management-social-signon-button-disconnect": (
+					"color": var(--global-black),
+					"border-color": var(--global-black),
+				),
+				"account-management-social-signon-edit": (
+					"align-items": center,
+					"border-color": var(--border-color),
+					"border-radius": var(--border-radius),
+					"border-style": var(--global-border-style-1),
+					"border-width": var(--global-border-width-1),
+					"display": flex,
+					"justify-content": space-between,
+					"margin-block-end": var(--global-spacing-2),
+					"padding-block-start": var(--global-spacing-4),
+					"padding-block-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
+					"padding-inline-end": var(--global-spacing-4),
+					"min-width": 280px,
+				),
+				"account-management-social-signon-identities-error": (
+					"font-family": var(--font-family-primary),
+					"margin-block-end": var(--global-spacing-4),
+					"components": (
+						"paragraph": (
+							"background-color": var(--status-color-danger-subtle),
+							"color": var(--status-color-danger),
+							"padding-block-end": var(--global-spacing-1),
+							"padding-block-start": var(--global-spacing-1),
+							"padding-inline-start": var(--global-spacing-2),
+							"padding-inline-end": var(--global-spacing-2),
+						),
+					),
+				),
+				"account-management-social-signon-identity": (
+					"display": flex,
+					"components": (
+						"icon": (
+							"margin-inline-end": var(--global-spacing-2),
+						),
+					),
+				),
 				"ads-block": (
 					"components": (
 						"paragraph": (
@@ -768,23 +829,173 @@
 					"padding-inline-start": var(--global-spacing-4),
 				),
 				"checkout": (
-					"font-family": var(--font-family-primary),
+					"display": flex,
+				),
+				"checkout-billing-address": (
+					"margin-block-start": var(--global-spacing-6),
+					"components": (
+						"heading": (
+							"margin-block-end": var(--global-spacing-5),
+							"font-size": var(--global-font-size-11),
+						),
+						"input-error-tip": (
+							"color": var(--status-color-danger),
+						),
+						"input-input": (
+							"inline-size": 100%,
+							"padding-block-end": var(--global-spacing-2),
+							"padding-block-start": var(--global-spacing-2),
+							"padding-inline-end": var(--global-spacing-2),
+							"padding-inline-start": var(--global-spacing-2),
+						),
+					),
+				),
+				"checkout-billing-address-captcha": (
+					"margin-block-start": var(--global-spacing-6),
+					"margin-block-end": var(--global-spacing-6),
+					"components": (
+						"paragraph": (
+							"color": var(--status-color-danger),
+							"font-family": var(--font-family-primary),
+						),
+					),
+				),
+				"checkout-billing-address-form-div": (
+					"margin-block-end": var(--global-spacing-4),
+				),
+				"checkout-billing-address-input-div": (
+					"display": grid,
+					"inline-size": 100%,
+					"grid-template-columns": repeat(2, 1fr),
+					"column-gap": var(--global-spacing-5),
+				),
+				"checkout-card": (
+					"display": flex,
+					"flex-direction": row,
+					"margin-block-start": var(--global-spacing-4),
 					"margin-block-end": var(--global-spacing-5),
 					"components": (
 						"heading": (
-							"font-size": var(--global-font-size-12),
+							"font-size": 20px,
+							"font-weight": 700,
+							"min-width": max-content,
+							"margin-inline-end": 0,
+							"margin-block-end": 0,
 						),
-						"link": (
-							"color": var(--color-primary),
-							"border-block-end-width": 1px,
-							"border-block-end-style": solid,
-							"border-block-end-color": var(--color-primary),
+						"paragraph": (
+							"color": var(--text-color-subtle),
 						),
-						"link-hover": (
-							"color": var(--color-primary-hover),
-							"border-block-end-width": 1px,
-							"border-block-end-style": solid,
-							"border-block-end-color": var(--color-primary-hover),
+					),
+				),
+				"checkout-card-children-div": (
+					"margin-inline-start": var(--global-spacing-5),
+					"margin-inline-end": var(--global-spacing-5),
+					"margin-block-start": var(--global-spacing-4),
+					"margin-block-end": var(--global-spacing-4),
+				),
+				"checkout-card-closed": (
+					"display": flex,
+					"flex-direction": row,
+					"margin-block-start": var(--global-spacing-4),
+					"margin-block-end": var(--global-spacing-5),
+					"components": (
+						"heading": (
+							"color": var(--text-color-subtle),
+							"font-size": 20px,
+							"font-weight": 700,
+							"min-width": max-content,
+							"margin-inline-end": 0,
+							"margin-block-end": 0,
+						),
+						"paragraph": (
+							"color": var(--text-color-subtle),
+						),
+					),
+				),
+				"checkout-card-edit": (
+					"text-decoration": underline,
+					"font-family": var(--font-family-primary),
+					"font-size": 16px,
+					"line-height": 24px,
+					"font-weight": 400,
+					"color": var(--color-primary),
+					"padding-block-end": 0,
+					"padding-block-start": 0,
+					"padding-inline-end": 0,
+					"padding-inline-start": 0,
+				),
+				"checkout-card-formError": (
+					"padding-block-start": var(--global-spacing-5),
+					"padding-inline-end": var(--global-spacing-5),
+					"padding-block-end": var(--global-spacing-5),
+					"padding-inline-start": var(--global-spacing-5),
+					"color": var(--global-white),
+					"background-color": var(--status-color-danger),
+					"components": (
+						"paragraph": (
+							"font-size": var(--global-font-size-4),
+							"font-family": var(--font-family-primary),
+							"font-weight": var(--global-font-weight-4),
+						),
+					),
+				),
+				"checkout-card-paymentOptions": (
+					"display": flex,
+					"border-radius": var(--border-radius),
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-style": solid,
+					"border-block-end-style": solid,
+					"border-inline-start-style": solid,
+					"border-inline-end-style": solid,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"padding-block-end": var(--global-spacing-3),
+					"padding-block-start": var(--global-spacing-3),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
+					"gap": var(--global-spacing-4),
+					"components": (
+						"input-label": (
+							"font-size": var(--global-font-size-4),
+							"font-family": var(--font-family-secondary),
+							"font-weight": var(--global-font-weight-7),
+						),
+						"input-radio": (
+							"margin-block-start": 0,
+							"margin-inline-end": var(--global-spacing-2),
+							"margin-block-end": 0,
+							"margin-inline-start": 0,
+						),
+						"input-radio-checked": (
+							"border-color": red,
+							"background-color": red,
+						),
+						"icon": (
+							"inline-size": none,
+						),
+					),
+				),
+				"checkout-card-summary": (
+					"display": flex,
+					"justify-content": space-between,
+					"width": 100%,
+					"align-items": center,
+					"components": (
+						"paragraph": (
+							"font-size": 14px,
+							"align-items": center,
+						),
+					),
+				),
+				"checkout-card-summary-icon": (
+					"components": (
+						"icon": (
+							"inline-size": none,
 						),
 					),
 				),
@@ -830,34 +1041,6 @@
 					"border-inline-start-color": var(--border-color),
 					"border-inline-end-color": var(--border-color),
 				),
-				"checkout-contact-info": (
-					"margin-block-start": var(--global-spacing-6),
-					"components": (
-						"heading": (
-							"margin-block-end": var(--global-spacing-5),
-							"font-size": var(--global-font-size-11),
-						),
-						"input": (
-							"margin-block-end": var(--global-spacing-5),
-						),
-						"input-error-tip": (
-							"color": var(--status-color-danger),
-						),
-						"input-input": (
-							"inline-size": 100%,
-							"padding-block-end": var(--global-spacing-2),
-							"padding-block-start": var(--global-spacing-2),
-							"padding-inline-end": var(--global-spacing-2),
-							"padding-inline-start": var(--global-spacing-2),
-						),
-					),
-				),
-				"checkout-contact-info-profile": (
-					"display": grid,
-					"inline-size": 100%,
-					"grid-template-columns": repeat(2, 1fr),
-					"column-gap": var(--global-spacing-5),
-				),
 				"checkout-identity-row": (
 					"inline-size": 100%,
 					"display": inline-flex,
@@ -883,13 +1066,138 @@
 						),
 					),
 				),
+				"checkout-main": (
+					"display": flex,
+					"justify-content": center,
+					"inline-size": 100%,
+					"padding-block-start": var(--global-spacing-6),
+					"padding-inline-start": var(--global-spacing-6),
+					"padding-block-end": var(--global-spacing-6),
+					"padding-inline-end": var(--global-spacing-6),
+					"align-items": start,
+				),
+				"checkout-main-full": (
+					"display": flex,
+					"justify-content": center,
+					"inline-size": 100%,
+					"padding-block-start": var(--global-spacing-6),
+					"padding-inline-start": var(--global-spacing-6),
+					"padding-block-end": var(--global-spacing-6),
+					"padding-inline-end": var(--global-spacing-6),
+					"align-items": start,
+				),
+				"checkout-order-card": (
+					"display": flex,
+					"flex-direction": column,
+					"padding-block-start": var(--global-spacing-4),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-block-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
+					"gap": var(--global-spacing-5),
+					"column-gap": var(--global-spacing-5),
+					"components": (
+						"link": (
+							"color": var(--text-color),
+							"text-decoration": underline,
+							"font-size": var(--global-font-size-4),
+							"font-weight": var(--global-font-weight-4),
+						),
+						"heading": (
+							"margin-block-end": 0,
+						),
+					),
+				),
+				"checkout-order-card--features": (
+					"align-self": baseline,
+				),
+				"checkout-order-card--features--item": (
+					"align-items": center,
+					"display": flex,
+					"margin-block-end": var(--global-spacing-2),
+					"components": (
+						"icon": (
+							"fill": var(--status-color-success),
+							"display": flex,
+							"inline-size": var(--global-spacing-4),
+							"block-size": var(--global-spacing-4),
+							"margin-block-start": 0,
+							"margin-inline-end": var(--global-spacing-2),
+							"margin-block-end": 0,
+							"margin-inline-start": 0,
+						),
+					),
+				),
+				"checkout-order-card--summary": (
+					"gap": var(--global-spacing-2),
+					"components": (
+						"heading": (
+							"font-family": var(--font-family-secondary),
+							"font-weight": var(--global-font-weight-7),
+							"font-size": var(--global-font-size-4),
+							"padding-block-end": var(--global-spacing-2),
+							"border-block-end-width": 1px,
+							"border-block-end-style": solid,
+							"border-block-end-color": var(--border-color),
+						),
+					),
+				),
+				"checkout-order-card--summary--details": (
+					"gap": var(--global-spacing-2),
+				),
+				"checkout-order-card--summary--details--item": (
+					"flex-direction": row,
+					"justify-content": space-between,
+					"font-family": var(--font-family-primary),
+					"font-weight": var(--global-font-weight-4),
+					"font-size": var(--global-font-size-3),
+				),
+				"checkout-order-card--summary--dueToday": (
+					"display": flex,
+					"justify-content": space-between,
+					"padding-block-start": var(--global-spacing-2),
+					"border-block-start-width": 1px,
+					"border-block-start-style": solid,
+					"border-block-start-color": var(--border-color),
+					"font-family": var(--font-family-secondary),
+					"font-weight": var(--global-font-weight-7),
+					"font-size": var(--global-font-size-7),
+					"inline-size": 100%,
+					"align-items": flex-start,
+				),
+				"checkout-order-card-border": (
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-style": solid,
+					"border-block-end-style": solid,
+					"border-inline-start-style": solid,
+					"border-inline-end-style": solid,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"border-radius": var(--border-radius),
+				),
+				"checkout-order-card-productPrice": (
+					"display": flex,
+					"flex-direction": column,
+					"gap": var(--global-spacing-5),
+					"column-gap": var(--global-spacing-5),
+					"components": (
+						"heading": (
+							"font-size": var(--global-font-size-9),
+							"font-weight": var(--global-font-weight-7),
+							"line-height": var(--global-line-height-6),
+						),
+					),
+				),
 				"checkout-payment": (
 					"inline-size": 100%,
 				),
 				"checkout-payment-form": (
 					"display": grid,
-					"margin-block-start": var(--global-spacing-5),
-					"gap": var(--global-spacing-6),
+					"gap": var(--global-spacing-5),
 				),
 				"checkout-payment-form--border-bottom": (
 					"border-block-end-width": 1px,
@@ -941,11 +1249,21 @@
 						"padding-inline-start": 0,
 					),
 				),
+				"checkout-payment-form--stripe-countryZipCode": (
+					"display": grid,
+					"inline-size": 100%,
+					"grid-template-columns": repeat(2, 1fr),
+					"column-gap": var(--global-spacing-5),
+				),
 				"checkout-payment-form--stripe-element": (
 					"padding-block-start": var(--global-spacing-2),
 					"padding-inline-end": var(--global-spacing-2),
 					"padding-block-end": var(--global-spacing-2),
 					"padding-inline-start": var(--global-spacing-2),
+				),
+				"checkout-payment-form--stripe-error": (
+					"color": var(--status-color-danger),
+					"font-size": var(--global-font-size-3),
 				),
 				"checkout-payment-form--stripe-input-container": (
 					"display": grid,
@@ -953,8 +1271,8 @@
 				),
 				"checkout-payment-form--stripe-label": (
 					"font-size": var(--global-font-size-4),
-					"font-weight": var(--global-font-weight-4),
-					"color": var(--global-neutral-7),
+					"font-weight": var(--global-font-weight-7),
+					"font-family": var(--font-family-secondary),
 				),
 				"checkout-payment-form--stripe-row": (
 					"display": grid,
@@ -1041,7 +1359,7 @@
 				),
 				"checkout-payment-information": (
 					"inline-size": 100%,
-					"gap": var(--global-spacing-5),
+					"gap": var(--global-spacing-3),
 					"grid-template-columns": 1fr,
 					"components": (
 						"input-error-tip": (
@@ -1049,8 +1367,8 @@
 						),
 						"input-label": (
 							"font-size": var(--global-font-size-4),
-							"font-weight": var(--global-font-weight-4),
-							"color": var(--global-neutral-7),
+							"font-weight": var(--global-font-weight-7),
+							"font-family": var(--font-family-secondary),
 						),
 						"input-input": (
 							"inline-size": 100%,
@@ -1060,6 +1378,112 @@
 							"padding-inline-start": var(--global-spacing-2),
 						),
 					),
+				),
+				"checkout-payment-paypal-button": (
+					"background-color": #ffc43a,
+					"color": var(--text-color),
+					"components": (
+						"icon": (
+							"inline-size": none,
+						),
+					),
+				),
+				"checkout-review": (
+					"gap": var(--global-spacing-4),
+					"components": (
+						"paragraph": (
+							"margin-block-end": 0,
+						),
+					),
+				),
+				"checkout-review-orderInformation": (
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-style": solid,
+					"border-block-end-style": solid,
+					"border-inline-start-style": solid,
+					"border-inline-end-style": solid,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"border-radius": var(--border-radius),
+					"components": (
+						"heading": (
+							"margin-block-end": 0,
+						),
+					),
+				),
+				"checkout-review-renewalInformation": (
+					"font-family": var(--font-family-secondary),
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-style": solid,
+					"border-block-end-style": solid,
+					"border-inline-start-style": solid,
+					"border-inline-end-style": solid,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"border-radius": var(--border-radius),
+					"padding-block-start": var(--global-spacing-4),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-block-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
+					"gap": var(--global-spacing-4),
+					"components": (
+						"heading": (
+							"margin-block-end": 0,
+							"font-weight": var(--global-font-weight-7),
+							"font-size": var(--global-font-size-4),
+						),
+					),
+				),
+				"checkout-review-tos-link": (
+					"color": var(--text-color),
+					"text-decoration": underline,
+				),
+				"checkout-review-tos-link-hover": (
+					"color": var(--text-color-subtle),
+				),
+				"checkout-section": (
+					"font-family": var(--font-family-primary),
+					"margin-block-end": var(--global-spacing-5),
+					"max-width": 650px,
+					"components": (
+						"heading": (
+							"font-size": var(--heading-level-4-font-size),
+							"font-family": var(--font-family-secondary),
+							"margin-block-end": var(--global-spacing-5),
+						),
+						"link": (
+							"color": var(--color-primary),
+							"border-block-end-width": 1px,
+							"border-block-end-style": solid,
+							"border-block-end-color": var(--color-primary),
+						),
+						"link-hover": (
+							"color": var(--color-primary-hover),
+							"border-block-end-width": 1px,
+							"border-block-end-style": solid,
+							"border-block-end-color": var(--color-primary-hover),
+						),
+					),
+				),
+				"checkout-sidebar": (
+					"display": none,
+					"height": 100vh,
+					"border-inline-start-width": 2px,
+					"border-inline-start-style": solid,
+					"border-inline-start-color": #dadada,
+					"padding-block-start": var(--global-spacing-6),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-6),
 				),
 				"double-chain": (
 					"components": (
@@ -1467,6 +1891,23 @@
 						),
 					),
 				),
+				"header-nav-chain-flyout-close-button": (
+					"align-self": flex-end,
+					"block-size": var(--global-spacing-5),
+					"margin-inline-end": var(--global-spacing-5),
+					"components": (
+						"button": (
+							"border-width": 0,
+							"block-size": auto,
+						),
+						"button-small": (
+							"padding-block-end": 0,
+							"padding-block-start": 0,
+							"padding-inline-end": 0,
+							"padding-inline-start": 0,
+						),
+					),
+				),
 				"header-nav-chain-flyout-nav": (
 					"block-size": calc((100vh - var(--header-nav-chain-height-scrolled))),
 					"gap": 0,
@@ -1496,8 +1937,6 @@
 				),
 				"header-nav-chain-flyout-nav-components-desktop": (
 					"display": none,
-					"padding-block-end": var(--global-spacing-5),
-					"padding-block-start": var(--global-spacing-5),
 					"padding-inline-end": var(--global-spacing-5),
 					"padding-inline-start": var(--global-spacing-5),
 					"components": (
@@ -1508,8 +1947,6 @@
 				),
 				"header-nav-chain-flyout-nav-components-mobile": (
 					"display": flex,
-					"padding-block-end": var(--global-spacing-5),
-					"padding-block-start": var(--global-spacing-5),
 					"padding-inline-end": var(--global-spacing-5),
 					"padding-inline-start": var(--global-spacing-5),
 				),
@@ -1618,6 +2055,7 @@
 				),
 				"header-nav-chain-flyout-nav-wrapper-open": (
 					"gap": var(--global-spacing-4),
+					"padding-block-start": var(--global-spacing-4),
 				),
 				"header-nav-chain-flyout-overlay": (
 					"margin-block-start": var(--header-nav-chain-height),
@@ -1636,6 +2074,7 @@
 				),
 				"header-nav-chain-flyout-overlay-open": (
 					"background": var(--header-nav-chain-overlay-background-color),
+					"block-size": calc(100vh - var(--header-nav-chain-height)),
 					"overflow-y": scroll,
 					"overflow-block": scroll,
 					"transform": translate(0, 0),
@@ -1987,7 +2426,7 @@
 				),
 				"login-form": (
 					"font-family": var(--font-family-primary),
-					"padding-block-end": var(--global-spacing-5),
+					"padding-block-end": var(--global-spacing-2),
 					"components": (
 						"button": (
 							"font-size": var(--global-font-size-4),
@@ -1999,11 +2438,10 @@
 							"font-style": normal,
 							"line-height": 140%,
 							"text-align": center,
-							"padding-block-end": 0,
 							"padding-block-start": 0,
 							"padding-inline-end": 0,
-							"padding-inline-start": 0,
-							"margin-block-end": var(--global-spacing-5),
+							"margin-block-end": var(--global-spacing-0),
+							"padding-block-end": var(--global-spacing-2),
 						),
 						"input": (
 							"margin-block-end": var(--global-spacing-4),
@@ -2085,6 +2523,17 @@
 						),
 					),
 				),
+				"login-form-tos-container-link": (
+					"margin-block-start": var(--global-spacing-5),
+					"margin-block-end": var(--global-spacing-5),
+				),
+				"login-form-tos-link": (
+					"color": var(--text-color),
+					"text-decoration": underline,
+				),
+				"login-form-tos-link-hover": (
+					"color": var(--text-color-subtle),
+				),
 				"login-links": (
 					"font-family": var(--font-family-primary),
 					"components": (
@@ -2107,6 +2556,9 @@
 					"margin-inline-end": 0,
 					"margin-inline-start": 0,
 					"padding-inline-start": var(--global-spacing-2),
+				),
+				"login-links-ota-link": (
+					"border": 1px solid var(--border-color),
 				),
 				"masthead": (
 					"border-block-end": 2px solid var(--global-neutral-8),
@@ -2427,6 +2879,60 @@
 				"offer-wrapper": (
 					"margin-block-start": var(--global-spacing-5),
 					"margin-block-end": var(--global-spacing-6),
+				),
+				"one-time-login-form": (
+					"font-family": var(--font-family-primary),
+					"components": (
+						"button": (
+							"font-size": var(--global-font-size-4),
+						),
+						"heading": (
+							"border-block-end-color": var(--border-color),
+							"border-block-end-style": var(--global-border-style-0),
+							"border-block-end-width": var(--global-border-width-0),
+							"font-size": var(--global-font-size-12),
+							"margin-block-end": var(--global-spacing-4),
+							"padding-block-end": 0,
+							"text-align": center,
+						),
+						"input": (
+							"margin-block-end": var(--global-spacing-5),
+						),
+						"input-error-tip": (
+							"color": var(--status-color-danger),
+						),
+						"input-input": (
+							"inline-size": 100%,
+							"padding-block-end": var(--global-spacing-2),
+							"padding-block-start": var(--global-spacing-2),
+						),
+						"paragraph": (
+							"font-family": var(--font-family-primary),
+							"margin-block-end": var(--global-spacing-5),
+						),
+					),
+				),
+				"ota-form-error": (
+					"font-family": var(--font-family-primary),
+					"text-align": center,
+					"margin-block-end": var(--global-spacing-4),
+					"components": (
+						"paragraph": (
+							"background-color": var(--status-color-danger-subtle),
+							"color": var(--status-color-danger),
+							"padding-block-end": var(--global-spacing-1),
+							"padding-block-start": var(--global-spacing-1),
+							"padding-inline-start": var(--global-spacing-2),
+							"padding-inline-end": var(--global-spacing-2),
+						),
+					),
+				),
+				"ota-recaptcha": (
+					"margin-block-end": var(--global-spacing-4),
+				),
+				"ota-sub-headline": (
+					"text-align": center,
+					"margin-block-end": var(--global-spacing-4),
 				),
 				"paywall-overlay": (
 					"background-color": rgba(0, 0, 0, 0.63),
@@ -2934,18 +3440,22 @@
 				),
 				"sign-up": (
 					"font-family": var(--font-family-primary),
+					"padding-block-end": var(--global-spacing-2),
 					"components": (
 						"button": (
 							"font-size": var(--global-font-size-4),
 						),
 						"heading": (
-							"border-block-end-color": var(--border-color),
-							"border-block-end-style": var(--global-border-style-0),
-							"border-block-end-width": var(--global-border-width-1),
-							"font-size": var(--global-font-size-9),
-							"margin-block-end": var(--global-spacing-4),
-							"padding-block-end": var(--global-spacing-2),
+							"font-size": var(--heading-level-4-font-size),
+							"font-family": var(--font-family-secondary),
+							"font-weight": 700,
+							"font-style": normal,
+							"line-height": 140%,
 							"text-align": center,
+							"padding-block-start": 0,
+							"padding-inline-end": 0,
+							"margin-block-end": var(--global-spacing-0),
+							"padding-block-end": var(--global-spacing-2),
 						),
 						"input": (
 							"margin-block-end": var(--global-spacing-5),
@@ -2967,7 +3477,23 @@
 						),
 					),
 				),
+				"sign-up-form-error": (
+					"font-family": var(--font-family-primary),
+					"text-align": center,
+					"margin-block-end": var(--global-spacing-4),
+					"components": (
+						"paragraph": (
+							"background-color": var(--status-color-danger-subtle),
+							"color": var(--status-color-danger),
+							"padding-block-end": var(--global-spacing-1),
+							"padding-block-start": var(--global-spacing-1),
+							"padding-inline-start": var(--global-spacing-2),
+							"padding-inline-end": var(--global-spacing-2),
+						),
+					),
+				),
 				"sign-up-tos-container-link": (
+					"margin-block-start": var(--global-spacing-5),
 					"margin-block-end": var(--global-spacing-5),
 				),
 				"sign-up-tos-link": (
@@ -3144,6 +3670,57 @@
 						),
 					),
 				),
+				"social-sign-on-button-container-apple-custom": (
+					"inline-size": 100%,
+				),
+				"social-sign-on-button-container-facebook": (
+					"justify-content": center,
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"border-radius": var(--global-spacing-1),
+					"color": var(--text-color),
+					"font-weight": var(--global-font-weight-7),
+					"font-family": var(--font-family-primary),
+					"inline-size": 100%,
+					"components": (
+						"button-secondary-reverse-hover": (
+							"color": var(--text-color),
+						),
+						"icon": (
+							"fill": #4285f4,
+						),
+					),
+				),
+				"social-sign-on-button-container-google": (
+					"justify-content": center,
+					"border-block-start-width": 1px,
+					"border-block-end-width": 1px,
+					"border-inline-start-width": 1px,
+					"border-inline-end-width": 1px,
+					"border-block-start-color": var(--border-color),
+					"border-block-end-color": var(--border-color),
+					"border-inline-start-color": var(--border-color),
+					"border-inline-end-color": var(--border-color),
+					"border-radius": var(--global-spacing-1),
+					"color": var(--text-color),
+					"font-weight": var(--global-font-weight-7),
+					"font-family": var(--font-family-primary),
+					"inline-size": 100%,
+					"components": (
+						"button-secondary-reverse-hover": (
+							"color": var(--text-color),
+						),
+						"icon": (
+							"fill": #4285f4,
+						),
+					),
+				),
 				"social-sign-on-dividerWithText": (
 					"display": flex,
 					"align-items": center,
@@ -3172,6 +3749,258 @@
 					"font-size": var(--heading-level-6-font-size),
 					"font-weight": var(--heading-level-6-font-weight),
 					"line-height": var(--heading-level-6-line-height),
+				),
+				"subscriptions-subscription-list-card": (
+					"padding-block-end": var(--global-spacing-4),
+					"padding-block-start": var(--global-spacing-4),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
+					"border": solid 1px #8593aa,
+					"border-radius": 4px,
+					"margin-block-end": var(--global-spacing-5),
+				),
+				"subscriptions-subscription-list-detail-billing": (
+					"font-family": var(--font-family-secondary),
+					"font-weight": 700,
+					"size": 16px,
+					"color": var(--text-color),
+					"line-height": 24px,
+					"margin-block-start": var(--global-spacing-4),
+					"display": flex,
+					"components": (
+						"paragraph": (
+							"margin-inline-start": var(--global-spacing-4),
+							"font-weight": 400,
+							"font-size": 14px,
+							"line-height": 21px,
+							"color": var(--text-color-subtle),
+						),
+					),
+				),
+				"subscriptions-subscription-list-detail-billing-subtitle": (
+					"min-inline-size": max-content,
+					"display": block,
+				),
+				"subscriptions-subscription-list-detail-cancel": (
+					"font-size": 16px,
+					"font-family": Inter,
+					"font-weight": 400,
+					"line-height": 24px,
+					"align-self": center,
+					"block-size": 24px,
+					"text-decoration": underline,
+					"padding-inline-start": 0,
+				),
+				"subscriptions-subscription-list-detail-cancel-badge": (
+					"background-color": var(--global-orange-2),
+					"color": var(--text-color),
+				),
+				"subscriptions-subscription-list-detail-cancel-info": (
+					"background-color": var(--global-orange-2),
+					"padding-block-end": 24px,
+					"padding-block-start": 24px,
+					"padding-inline-end": 24px,
+					"padding-inline-start": 24px,
+					"margin-block-start": var(--global-spacing-4),
+					"justify-content": space-between,
+					"display": flex,
+					"font-family": Inter,
+					"font-size": 16px,
+					"line-height": 24px,
+					"font-weight": 400,
+				),
+				"subscriptions-subscription-list-detail-cancel-info-button": (
+					"background-color": transparent,
+				),
+				"subscriptions-subscription-list-detail-cancel-info-button-hover": (
+					"cursor": pointer,
+				),
+				"subscriptions-subscription-list-detail-div": (
+					"margin-block-end": var(--global-spacing-4),
+				),
+				"subscriptions-subscription-list-detail-inactive-sub": (
+					"font-family": var(--font-family-secondary),
+					"font-weight": 700,
+					"font-size": 16px,
+					"color": var(--text-color),
+					"line-height": 24px,
+					"display": flex,
+					"flex-direction": row,
+					"components": (
+						"paragraph": (
+							"margin-inline-start": var(--global-spacing-2),
+							"font-weight": 400,
+						),
+					),
+				),
+				"subscriptions-subscription-list-detail-inactive-sub-paragraph": (
+					"font-weight": 500,
+					"font-size": 14px,
+					"line-height": 16px,
+					"font-family": sans-serif,
+					"color": var(--text-color-subtle),
+				),
+				"subscriptions-subscription-list-detail-payment-billing-frequency": (
+					"font-family": var(--font-family-secondary),
+					"font-weight": 500,
+					"font-size": 14px,
+					"line-height": 16px,
+					"color": var(--text-color-subtle),
+				),
+				"subscriptions-subscription-list-detail-payment-container": (
+					"margin-block-start": var(--global-spacing-2),
+					"margin-block-end": var(--global-spacing-2),
+					"display": flex,
+					"flex-direction": column,
+				),
+				"subscriptions-subscription-list-detail-payment-next-bill": (
+					"font-family": var(--font-family-secondary),
+					"font-weight": 700,
+					"font-size": 16px,
+					"line-height": 24px,
+					"margin-block-end": var(--global-spacing-2),
+					"components": (
+						"paragraph": (
+							"font-weight": 400,
+						),
+					),
+				),
+				"subscriptions-subscription-list-detail-payment-title": (
+					"justify-content": space-between,
+					"display": flex,
+					"align-items": center,
+					"margin-block-end": var(--global-spacing-2),
+				),
+				"subscriptions-subscription-list-detail-payment-title-payment-info": (
+					"margin-inline-start": var(--global-spacing-4),
+					"font-family": Lora,
+					"font-size": 14px,
+					"font-weight": 400,
+					"line-height": 21px,
+					"display": flex,
+					"align-items": center,
+					"components": (
+						"paragraph": (
+							"margin-inline-start": 4px,
+						),
+					),
+				),
+				"subscriptions-subscription-list-detail-payment-title-span": (
+					"font-family": Lora,
+					"font-size": 16px,
+					"font-weight": 700,
+					"line-height": 24px,
+					"color": var(--text-color),
+					"display": flex,
+				),
+				"subscriptions-subscription-list-detail-payment-visa-icon": (
+					"block-size": 26px,
+					"inline-size": 37px,
+					"display": flex,
+					"justify-content": center,
+					"border": solid 1px lightgray,
+					"border-radius": 5px,
+					"margin-inline-end": 4px,
+					"align-content": center,
+					"flex-wrap": wrap,
+				),
+				"subscriptions-subscription-list-detail-startDate": (
+					"font-size": 14px,
+					"font-family": Inter,
+					"font-weight": 500,
+					"line-height": 16px,
+					"block-size": 24px,
+					"color": var(--text-color),
+				),
+				"subscriptions-subscription-list-detail-subID": (
+					"font-size": 12px,
+					"font-family": Inter,
+					"font-weight": 400,
+					"line-height": 18px,
+					"block-size": 18px,
+					"color": var(--text-color-subtle),
+					"margin-block-end": var(--global-spacing-4),
+				),
+				"subscriptions-subscription-list-detail-title": (
+					"font-size": 20px,
+					"font-family": Inter,
+					"font-weight": 700,
+					"line-height": 28px,
+					"align-self": center,
+					"inline-size": 100%,
+					"margin-block-end": var(--global-spacing-2),
+				),
+				"subscriptions-subscription-list-detail-title-div": (
+					"display": flex,
+					"flex-direction": row,
+					"justify-content": space-between,
+					"block-size": max-content,
+					"align-content": center,
+					"flex-wrap": wrap,
+				),
+				"subscriptions-subscription-list-detail-title-sub-info": (
+					"display": flex,
+					"flex-direction": column,
+				),
+				"subscriptions-subscription-list-modal": (
+					"font-family": sans-serif,
+					"font-weight": 500,
+					"font-size": 16px,
+					"line-heigth": 18.72px,
+					"display": flex,
+					"flex-direction": column,
+					"components": (
+						"paragraph": (
+							"margin-block-end": var(--global-spacing-2),
+						),
+					),
+				),
+				"subscriptions-subscription-list-modal-button-div": (
+					"display": flex,
+					"justify-content": flex-end,
+					"components": (
+						"button": (
+							"font-size": 16px,
+							"font-weight": 500,
+							"font-family": sans-serif,
+							"line-height": 19.2px,
+						),
+					),
+				),
+				"subscriptions-subscription-list-modal-title": (
+					"font-size": 32px,
+					"font-weight": 500,
+					"line-height": 40px,
+					"font-family": sans-serif,
+					"margin-block-end": var(--global-spacing-2),
+				),
+				"subscriptions-subscription-list-overlay": (
+					"background-color": rgba(179, 191, 210, 0.7),
+					"inset-block-end": 0,
+					"inset-inline-start": 0,
+					"inset-inline-end": 0,
+					"inset-block-start": 0,
+					"overflow": auto,
+					"pointer-events": all,
+					"position": fixed,
+					"block-size": 100vh,
+					"z-index": 1,
+				),
+				"subscriptions-subscription-list-overlay-content": (
+					"background-color": var(--global-white),
+					"margin-block-start": -105px,
+					"inset-block-start": 50%,
+					"position": absolute,
+					"inset-inline-start": 50%,
+					"inline-size": 475px,
+					"block-size": 211px,
+					"min-block-size": max-content,
+					"margin-inline-start": -237px,
+					"box-shadow": 4px 8px 8px 0px #999999,
+					"padding-block-end": var(--global-spacing-4),
+					"padding-block-start": var(--global-spacing-4),
+					"padding-inline-end": var(--global-spacing-4),
+					"padding-inline-start": var(--global-spacing-4),
 				),
 				"tag-title": (
 					"components": (
@@ -3288,7 +4117,7 @@
 							"margin-block-start": 0,
 							"margin-inline-end": 0,
 							"margin-inline-start": 0,
-							"max-inline-size": 100px,
+							"max-inline-size": 34%,
 						),
 						"heading": (
 							"font-size": var(--heading-level-5-font-size),
@@ -3345,9 +4174,10 @@
 					"margin-inline-start": var(--global-spacing-2),
 				),
 				"top-table-list-medium-show-image": (
+					"grid-template-columns": 66% auto,
 					"components": (
 						"heading": (
-							"inline-size": 68%,
+							"inline-size": 66%,
 						),
 					),
 				),
@@ -3377,7 +4207,7 @@
 					),
 				),
 				"top-table-list-small-left": (
-					"grid-template-columns": 1fr 2fr,
+					"grid-template-columns": auto 66%,
 					"components": (
 						"divider": (
 							"grid-column": span 2,
@@ -3385,7 +4215,7 @@
 					),
 				),
 				"top-table-list-small-right": (
-					"grid-template-columns": 2fr 1fr,
+					"grid-template-columns": 66% auto,
 					"components": (
 						"divider": (
 							"grid-column": span 2,
@@ -3656,6 +4486,7 @@
 				),
 				"button-primary-hover": (
 					"background-color": var(--color-primary-hover),
+					"color": var(--global-white),
 				),
 				"button-primary-reverse": (
 					"background-color": transparent,
@@ -3674,8 +4505,8 @@
 						),
 				),
 				"button-secondary-hover": (
-					"background-color": var(--global-neutral-2),
-					"color": var(--global-neutral-6),
+					"background-color": var(--color-primary-hover),
+					"color": var(--global-white),
 				),
 				"button-secondary-reverse": (
 					"background-color": transparent,
@@ -3683,15 +4514,15 @@
 					"color": var(--global-white),
 				),
 				"button-secondary-reverse-hover": (
-					"border-color": var(--global-neutral-3),
-					"color": var(--global-neutral-3),
+					"border-color": var(--color-primary-hover),
+					"color": var(--color-primary-hover),
 				),
 				"button-small": (
 					"font-size": var(--body-font-size-small),
 					"line-height": var(--body-line-height-small),
-					"padding-block-start": var(--global-spacing-1),
+					"padding-block-start": var(--global-spacing-2),
 					"padding-inline-start": var(--global-spacing-4),
-					"padding-block-end": var(--global-spacing-1),
+					"padding-block-end": var(--global-spacing-2),
 					"padding-inline-end": var(--global-spacing-4),
 				),
 				"carousel": (
@@ -3818,6 +4649,21 @@
 					"flex-direction": column,
 					"gap": var(--global-spacing-1),
 				),
+				"input-checked": (
+					"appearance": none,
+					"-webkit-appearance": none,
+					"-moz-appearance": none,
+					"width": 16px,
+					"height": 16px,
+					"border": 5px solid var(--global-blue-5),
+					"border-radius": 50%,
+					"cursor": pointer,
+					"position": relative,
+					"outline": none,
+					"box-sizing": border-box,
+					"padding": 0,
+					"border-color": var(--global-blue-5),
+				),
 				"input-error-input": (
 					"border-color": var(--status-color-danger),
 				),
@@ -3850,6 +4696,15 @@
 				"input-label": (
 					"font-weight": var(--global-font-weight-7),
 				),
+				"input-radio": (
+					"flex-direction": row,
+					"align-items": center,
+					"components": (
+						"input": (
+							"margin-block-end": var(--global-spacing-5),
+						),
+					),
+				),
 				"input-small-input": (
 					"padding-block-end": var(--global-spacing-2),
 					"padding-block-start": var(--global-spacing-2),
@@ -3861,6 +4716,9 @@
 				),
 				"input-success-input-focus": (
 					"outline-color": var(--status-color-success),
+				),
+				"input-tip": (
+					"font-size": var(--global-font-size-3),
 				),
 				"input-warning-input": (
 					"border-color": var(--status-color-warning),
@@ -3926,6 +4784,9 @@
 				),
 				"pill-hover": (
 					"background-color": var(--global-neutral-7),
+				),
+				"reCaptcha-warning": (
+					"color": var(--status-color-danger),
 				),
 				"stack-divider-horizontal": (
 					"border": none,
@@ -3997,6 +4858,12 @@
 				),
 				"author-bio-social-link-wrapper": (
 					"margin-block-start": var(--global-spacing-4),
+				),
+				"checkout-main": (
+					"inline-size": 80%,
+				),
+				"checkout-sidebar": (
+					"display": flex,
 				),
 				"double-chain": (
 					"components": (
@@ -4246,6 +5113,14 @@
 						),
 					),
 				),
+				"one-time-login-form": (
+					"components": (
+						"heading": (
+							"font-size": var(--global-font-size-11),
+							"padding-block-end": 0,
+						),
+					),
+				),
 				"quad-chain": (
 					"components": (
 						"stack": (
@@ -4460,6 +5335,7 @@
 					"display": inline,
 				),
 				"top-table-list-medium-show-image": (
+					"grid-template-columns": auto 66%,
 					"components": (
 						"attribution": (
 							"margin-inline-start": calc(33% + var(--global-spacing-6)),

--- a/src/components/button/themes/news.json
+++ b/src/components/button/themes/news.json
@@ -101,7 +101,7 @@
 		"styles": {
 			"default": {
 				"background-color": "var(--global-white)",
-				"color": "var (--global-black)"
+				"color": "var (--text-color)"
 			}
 		}
 	},

--- a/src/components/button/themes/news.json
+++ b/src/components/button/themes/news.json
@@ -16,9 +16,9 @@
 			"default": {
 				"font-size": "var(--body-font-size-small)",
 				"line-height": "var(--body-line-height-small)",
-				"padding-block-start": "var(--global-spacing-1)",
+				"padding-block-start": "var(--global-spacing-2)",
 				"padding-inline-start": "var(--global-spacing-4)",
-				"padding-block-end": "var(--global-spacing-1)",
+				"padding-block-end": "var(--global-spacing-2)",
 				"padding-inline-end": "var(--global-spacing-4)"
 			}
 		}
@@ -68,7 +68,8 @@
 	"button-primary-hover": {
 		"styles": {
 			"default": {
-				"background-color": "var(--color-primary-hover)"
+				"background-color": "var(--color-primary-hover)",
+				"color": "var(--global-white)"
 			}
 		}
 	},
@@ -100,8 +101,8 @@
 	"button-secondary-hover": {
 		"styles": {
 			"default": {
-				"background-color": "var(--global-neutral-2)",
-				"color": "var(--global-neutral-6)"
+				"background-color": "var(--color-primary-hover)",
+				"color": "var(--global-white)"
 			}
 		}
 	},
@@ -117,8 +118,8 @@
 	"button-secondary-reverse-hover": {
 		"styles": {
 			"default": {
-				"border-color": "var(--global-neutral-3)",
-				"color": "var(--global-neutral-3)"
+				"border-color": "var(--color-primary-hover)",
+				"color": "var(--color-primary-hover)"
 			}
 		}
 	}

--- a/src/components/button/themes/news.json
+++ b/src/components/button/themes/news.json
@@ -51,9 +51,16 @@
 		"styles": {
 			"default": {
 				"background-color": "var(--global-white)",
-				"border-color": "var(--global-neutral-7)",
+				"border-color": "var(--text-color)",
 				"border-width": "var(--global-border-width-1)",
-				"color": "var(--global-neutral-7)"
+				"color": "var(--text-color)"
+			}
+		}
+	},
+	"button-default-hover": {
+		"styles": {
+			"default": {
+				"color": "var(--color-primary-hover)"
 			}
 		}
 	},


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-1864](https://arcpublishing.atlassian.net/browse/THEMES-1864)

This PR fixes the styling for the button component. It was out of sync with what is in the Figma style docs. The button styles are located here: https://www.figma.com/design/NBjMF1v4mzwv9jkn7NEq9V/Themes-Block-Styling-2.0?node-id=10862-135976&t=YU12KWjCz73C7KdP-0.

## Test Steps

1. Checkout this branch - `git checkout THEMES-1864`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. Verify that the Button variants (on this page with storybook running http://localhost:6006/?path=/story/components-button--button-variants) `Primary`, `Primary-reverse`, `Secondary`, and `Secondary-reverse` match the Figma docs. Check both the at rest and hover states.


[THEMES-1864]: https://arcpublishing.atlassian.net/browse/THEMES-1864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ