### PR TITLE
A11y fix button label

### DIFF
--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -55,6 +55,7 @@ const Button = forwardRef((props, ref) => {
 	if (href) {
 		return (
 			<a {...defaultProps} href={href}>
+				{accessibilityLabel && <span className="visually-hidden">{accessibilityLabel}</span>}
 				{buttonContents}
 			</a>
 		);

--- a/src/components/button/index.jsx
+++ b/src/components/button/index.jsx
@@ -62,6 +62,7 @@ const Button = forwardRef((props, ref) => {
 	}
 	return (
 		<button {...defaultProps} type={type} aria-disabled={disabled}>
+			{accessibilityLabel && <span className="visually-hidden">{accessibilityLabel}</span>}
 			{buttonContents}
 		</button>
 	);


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

Added a visually hidden label that matches the button icon's aria-label for screen readers. 

I added these to both types of buttons (<a> and <button>). Share bar specifically uses the <button> markup. 

## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch - `git checkout a11y-fix-button-label`
2. Update dependencies - `npm i`
3. Run your feature pack with local components linked. Navigate to a template with a share bar. Examine the share bar to make sure there's no text, but inspect the element and ensure a visually hidden span with text to match the icon's aria-label. 
![Screenshot 2025-06-16 at 5 21 43 PM](https://github.com/user-attachments/assets/bcf00e9f-6775-4f99-a32c-08918676dde7)
![Screenshot 2025-06-16 at 5 21 47 PM](https://github.com/user-attachments/assets/d2dde8c2-8950-4355-bbc7-5dae6364b15f)

