### PR TITLE
Devint 477

### DIFF
--- a/src/components/meta-data/index.jsx
+++ b/src/components/meta-data/index.jsx
@@ -445,18 +445,23 @@ const MetaData = ({
 	);
 
 	if (outputCanonicalLink) {
-		const defaultResolution = getPageCanonicalUrl(
-			pageType,
-			canonicalDomain || websiteDomain,
-			gc,
-			requestUri,
-		);
-		const canonicalUrl = canonicalResolver
-			? canonicalResolver(pageType, defaultResolution)
-			: defaultResolution;
+		const externalCanonicalUrl = gc && gc.external_canonical_url;
+		if (externalCanonicalUrl) {
+			canonicalLink = <link rel="canonical" href={externalCanonicalUrl} />;
+		} else {
+			const defaultResolution = getPageCanonicalUrl(
+				pageType,
+				canonicalDomain || websiteDomain,
+				gc,
+				requestUri,
+			);
+			const canonicalUrl = canonicalResolver
+				? canonicalResolver(pageType, defaultResolution)
+				: defaultResolution;
 
-		if (canonicalUrl) {
-			canonicalLink = <link rel="canonical" href={canonicalUrl} />;
+			if (canonicalUrl) {
+				canonicalLink = <link rel="canonical" href={canonicalUrl} />;
+			}
 		}
 	}
 

--- a/src/components/meta-data/index.jsx
+++ b/src/components/meta-data/index.jsx
@@ -445,7 +445,7 @@ const MetaData = ({
 	);
 
 	if (outputCanonicalLink) {
-		const externalCanonicalUrl = gc && gc.external_canonical_url;
+		const externalCanonicalUrl = gc && gc.canonical_url_external;
 		if (externalCanonicalUrl) {
 			canonicalLink = <link rel="canonical" href={externalCanonicalUrl} />;
 		} else {

--- a/src/components/meta-data/index.test.jsx
+++ b/src/components/meta-data/index.test.jsx
@@ -13,6 +13,35 @@ afterEach(() => {
 });
 
 describe("MetaData (server-side)", () => {
+	it("uses globalContent.external_canonical_url for canonical link if present", () => {
+		useContent.mockReturnValue(null); // simplify
+		const metaValue = (key) => (key === "page-type" ? "article" : null);
+		const view = renderSSR(
+			<MetaData
+				arcSite="test-site"
+				websiteName="SiteName"
+				websiteDomain="https://example.com"
+				canonicalDomain="https://canonical.example.com"
+				outputCanonicalLink
+				metaValue={metaValue}
+				MetaTag={() => null}
+				MetaTags={() => null}
+				globalContent={{
+					canonical_url: "/story/slug/",
+					external_canonical_url: "https://external.example.com/story/override/",
+					websites: { "test-site": { website_url: "/story/slug/" } },
+				}}
+				resizerURL="https://resizer.example.com/"
+			/>,
+		);
+		expect(view).toContain(
+			'<link rel="canonical" href="https://external.example.com/story/override/"',
+		);
+		// Should NOT contain the fallback canonical
+		expect(view).not.toContain(
+			'<link rel="canonical" href="https://canonical.example.com/story/slug/"',
+		);
+	});
 	it("renders with minimal required props without throwing", () => {
 		const metaValue = (key) => (key === "page-type" ? "homepage" : null);
 		expect(() =>

--- a/src/components/meta-data/index.test.jsx
+++ b/src/components/meta-data/index.test.jsx
@@ -13,7 +13,7 @@ afterEach(() => {
 });
 
 describe("MetaData (server-side)", () => {
-	it("uses globalContent.external_canonical_url for canonical link if present", () => {
+	it("uses globalContent.canonical_url_external for canonical link if present", () => {
 		useContent.mockReturnValue(null); // simplify
 		const metaValue = (key) => (key === "page-type" ? "article" : null);
 		const view = renderSSR(
@@ -28,7 +28,7 @@ describe("MetaData (server-side)", () => {
 				MetaTags={() => null}
 				globalContent={{
 					canonical_url: "/story/slug/",
-					external_canonical_url: "https://external.example.com/story/override/",
+					canonical_url_external: "https://external.example.com/story/override/",
 					websites: { "test-site": { website_url: "/story/slug/" } },
 				}}
 				resizerURL="https://resizer.example.com/"


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

#### Jira Ticket: [DEVINT-477](https://arcpublishing.atlassian.net/browse/DEVINT-477)

Updated metadata component to use canonical_url_external field in <link rel="canonical"/> tag when the field exists. If not, it falls back to canonical_url field

**Article WITH canonical_url_external**
<img width="654" height="544" alt="Themes Version" src="https://github.com/user-attachments/assets/03575de1-0e45-416a-85e4-63514b06c5a3" />

<img width="1040" height="436" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/a18678d7-ca24-4049-b999-59f1e604cd73" />

**Article WITHOUT canonical_url_external**
<img width="603" height="248" alt="section20250702dave-" src="https://github.com/user-attachments/assets/66206f31-f6b0-4000-b46d-fe85ba5780be" />

<img width="1199" height="527" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/954f841b-6825-4f16-bc99-9288c36648c2" />


## Test Steps

There is very little test data with the canonical_url_external field. I used the staging prod environment as my content base, with test story: HVFACQ5XUJHC5HEW7UXULB626E

test url: http://localhost/pf/2025/08/28/external-url-test/?_website=raycom&mxId=00000000 


1. Checkout this branch - `git checkout DEVINT-477`
2. Update dependencies - `npm i`
2. Make sure you have your local components path set in your `.env`
4. run `npx fusion start -f -l` to link components


[DEVINT-477]: https://arcpublishing.atlassian.net/browse/DEVINT-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ