### PR TITLE
feat: passing loading attribute on images without auth token data

### DIFF
--- a/src/components/image/index.jsx
+++ b/src/components/image/index.jsx
@@ -36,7 +36,7 @@ const Image = ({
 		console.error("No auth token provided for resizer");
 
 		return (
-			<img alt={alt} className={componentClassNames} src={src} width={width} height={height} />
+			<img alt={alt} className={componentClassNames} loading={loading} src={src} width={width} height={height} />
 		);
 	}
 


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

Adding the `loading` attribute on images that don't have a Resizer auth token.

## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch - `git checkout img-loading-attr-no-auth`
2. Update dependencies - `npm i`
3. Remove your resizer auth token
4. Check for the loading attribute 
