### PR TITLE
fixed broken tests

### DIFF
--- a/src/utils/localize-date/index.test.js
+++ b/src/utils/localize-date/index.test.js
@@ -76,7 +76,7 @@ describe("localizeDateTime()", () => {
 	it("handles spanish meridiems", () => {
 		expect(
 			localizeDateTime("2000-01-02T13:00:00.000Z", "%B %d, %Y %l:%M %P %Z", "es", "Europe/Paris")
-		).toEqual("enero 02, 2000 2:00 p. m. CET");
+		).toEqual("enero 02, 2000 2:00 p. m. CET");
 	});
 
 	it("returns empty when no date is passed in", () => {
@@ -114,7 +114,7 @@ describe("localizeDateTime()", () => {
 	it("returns Portuguese locale", () => {
 		expect(
 			localizeDateTime("2000-01-02T01:00:00.000Z", "%B %d, %Y at %l:%M%p %Z", "pt", "America/New_York")
-		).toEqual("janeiro 01, 2000 at 8:00da tarde GMT-5");
+		).toEqual("janeiro 01, 2000 at 8:00p.m. GMT-5");
 	});
 
 	it("uses alternate formats", () => {


### PR DESCRIPTION
**Be sure to run `npm test`, `npm run lint`, and write detailed test steps before requesting reviewers**

## Description

Fixed Broken Tests:

1. Spanish meridiems — The p. m. string had a U+00A0 (non-breaking space) in the test but   
  the current Node/ICU version produces U+202F (narrow no-break space). Updated to match.     
  2. Portuguese locale — The test expected "da tarde" but the current ICU data returns "p.m." 
  for Portuguese. Updated to match.    

 Both are cosmetic differences from ICU data version changes across Node.js versions — the   
 underlying localization logic is correct.                                                        
                                                                                              

#### Jira Ticket: [MD-695](https://arcpublishing.atlassian.net/browse/MD-695)

_Information about what you changed for this PR. Include any dependencies, companion PRs, relevant screenshots, or config changes._

## Test Steps

_Add detailed test steps a reviewer must complete to test this PR_

1. Checkout this branch - `git checkout {branch name}`
2. Update dependencies - `npm i`
3. Run Storybook `npm run storybook`
4. {Next ....}


[MD-695]: https://arcpublishing.atlassian.net/browse/MD-695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ