### PR TITLE
Remove redundant URL import that breaks the build under PageBuilder 7.1

### DIFF
--- a/src/components/meta-data/index.jsx
+++ b/src/components/meta-data/index.jsx
@@ -7,7 +7,6 @@ import PropTypes from "prop-types";
 import { RESIZER_TOKEN_VERSION, ENVIRONMENT } from "fusion:environment";
 import { useContent } from "fusion:content";
 import getProperties from "fusion:properties";
-import { URL } from "url";
 import formatURL from "../../utils/format-url";
 import formatSrc from "../../utils/format-image-resizer-src";
 import getImageFromANS from "../../utils/get-image-from-ans";


### PR DESCRIPTION
## Description

#### Jira Ticket: [THEMES-](https://arcpublishing.atlassian.net/browse/THEMES-)

Removes the `import { URL } from "url"` statement in `src/components/meta-data/index.jsx`.

Under PageBuilder 7.1 this import breaks the build. `URL` is a global in modern Node runtimes, so the explicit import is both unnecessary and harmful — dropping it restores the build with no behavior change (`URL` continues to resolve to the built-in global).

**Change:** 1 line removed, single file (`src/components/meta-data/index.jsx`).

## Test Steps

1. Checkout this branch - `git checkout fix-for-pagebuilder-7.1`
2. Update dependencies - `npm i`
3. Run the test suite - `npm test` (should pass: 55 suites, 416 passed, 3 skipped)
4. Run lint - `npm run lint` (0 errors)
5. Verify the meta-data component still builds/renders under a PageBuilder 7.1 environment and that URLs produced by the component are unchanged.
